### PR TITLE
Fix hard coded constraints

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ c.MOSlurmSpawner.partitions = {
         "venv": "/jupyter_env_path/bin/",  # Path to Python environment bin/ used to start jupyter on the Slurm nodes 
         "max_ngpus": 0,                    # Maximum number of GPUs per node
         "max_nprocs": 28,                  # Maximum number of CPUs per node
+        "max_runtime": 12*3600,            # Maximum time limit in seconds
     },
     "partition_2": {
         "description": "Partition 2",
@@ -34,6 +35,7 @@ c.MOSlurmSpawner.partitions = {
         "venv": "/path/to/jupyter/env/for/partition_2/bin/",
         "max_ngpus": 2,
         "max_nprocs": 128,
+        "max_runtime": 1*3600,
     },
     "partition_3": {
         "description": "Partition 3",
@@ -43,6 +45,7 @@ c.MOSlurmSpawner.partitions = {
         "venv": "/path/to/jupyter/env/for/partition_3/bin/",
         "max_ngpus": 0,
         "max_nprocs": 28,
+        "max_runtime": 12*3600,
     },
 }
 ```

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ c.MOSlurmSpawner.partitions = {
         "venv": "/jupyter_env_path/bin/",  # Path to Python environment bin/ used to start jupyter on the Slurm nodes 
         "max_ngpus": 0,                    # Maximum number of GPUs per node
         "max_nprocs": 28,                  # Maximum number of CPUs per node
-        "max_runtime": 12*3600,            # Maximum time limit in seconds
+        "max_runtime": 12*3600,            # Maximum time limit in seconds (Must be at least 1hour)
     },
     "partition_2": {
         "description": "Partition 2",

--- a/jupyterhub_moss/form/option_form.js
+++ b/jupyterhub_moss/form/option_form.js
@@ -51,12 +51,13 @@ function setSimplePartition(name) {
 
   // Update available runtime options
   // Reset to 1 hour if choice is not available with current partition
-  if (runtimeSelection.value * 3600 > info['max_runtime']) {
+  if (runtimeSelect.value * 3600 > info['max_runtime']) {
     runtimeSelect.selectedIndex = 0;
-  }
-  runtimeSelect.options.forEach(element => {
+  };
+  for (i=0; i<runtimeSelect.options.length; i++) {
+    const element = runtimeSelect.options[i];
     setVisible(element, element.value * 3600 <= info['max_runtime']);
-  });
+  };
 }
 
 function updatePartitionLimits() {

--- a/jupyterhub_moss/form/option_form.js
+++ b/jupyterhub_moss/form/option_form.js
@@ -3,6 +3,14 @@ function resetSpawnForm() {
   setSimplePartition(window.SLURM_DATA.default_partition);
 }
 
+function setVisible(element, visible) {
+  if (visible) {
+    element.removeAttribute('hidden');
+  } else {
+    element.setAttribute('hidden', '');
+  }
+}
+
 function setSimplePartition(name) {
   const partitionElem = document.getElementById('partition');
   const gpuDivSimple = document.getElementById('gpu_simple');
@@ -20,11 +28,7 @@ function setSimplePartition(name) {
   const info = window.SLURM_DATA.partitions[name];
 
   // Toggle GPU choice display
-  if (info.max_ngpus !== 0) {
-    gpuDivSimple.removeAttribute('hidden');
-  } else {
-    gpuDivSimple.setAttribute('hidden', '');
-  }
+  setVisible(gpuDivSimple, info.max_ngpus !== 0);
 
   // Reset ngpus and GPUs choice
   gpuRadio0Simple.checked = true;
@@ -65,14 +69,9 @@ function updatePartitionLimits() {
 
   document.querySelectorAll('input[name="ngpus_simple"]').forEach(element =>
   {
-    const labelElem = document.querySelector(`label[for="${element.id}"]`)
-    if (element.value <= info.max_ngpus) {
-      element.removeAttribute('hidden');
-      labelElem.removeAttribute('hidden');
-    } else {
-      element.setAttribute('hidden', '');
-      labelElem.setAttribute('hidden', '');
-    }
+    const isVisible = element.value <= info.max_ngpus;
+    setVisible(element, isVisible);
+    setVisible(document.querySelector(`label[for="${element.id}"]`), isVisible);
   });
 }
 

--- a/jupyterhub_moss/form/option_form.js
+++ b/jupyterhub_moss/form/option_form.js
@@ -21,6 +21,7 @@ function setSimplePartition(name) {
   const maximumCpuFieldSimple = document.getElementById('maximumCpufield');
   const maximumCoreSimple = document.getElementById('maximumCore');
   const nprocsElem = document.getElementById('nprocs');
+  const runtimeSelect = document.getElementById('runtime_simple');
 
   partitionElem.value = name;
   updatePartitionLimits();
@@ -47,6 +48,15 @@ function setSimplePartition(name) {
   // Update nprocs according to current CPUs choice
   const selector = document.querySelector('input[name="nprocs_simple"]:checked');
   nprocsElem.value = selector ? selector.value : '1';
+
+  // Update available runtime options
+  // Reset to 1 hour if choice is not available with current partition
+  if (runtimeSelection.value * 3600 > info['max_runtime']) {
+    runtimeSelect.selectedIndex = 0;
+  }
+  runtimeSelect.options.forEach(element => {
+    setVisible(element, element.value * 3600 <= info['max_runtime']);
+  });
 }
 
 function updatePartitionLimits() {
@@ -113,7 +123,7 @@ document.addEventListener("DOMContentLoaded", () => {
   // Runtime
   document.getElementById('runtime_simple').addEventListener(
     'change', e => {
-      runtime.value = e.target.value;
+      runtime.value = `${e.target.value}:00:00`;
   });
 
   // Reset when returning to simple tab

--- a/jupyterhub_moss/spawner.py
+++ b/jupyterhub_moss/spawner.py
@@ -42,6 +42,7 @@ class MOSlurmSpawner(SlurmSpawner):
                 "venv": traitlets.Unicode(),
                 "max_ngpus": traitlets.Int(),
                 "max_nprocs": traitlets.Int(),
+                "max_runtime": traitlets.Int(),
             },
         ),
         key_trait=traitlets.Unicode(),

--- a/jupyterhub_moss/spawner.py
+++ b/jupyterhub_moss/spawner.py
@@ -132,7 +132,7 @@ class MOSlurmSpawner(SlurmSpawner):
             match = self._RUNTIME_REGEXP.match(options["runtime"])
             assert match is not None, "Error in runtime syntax"
             runtime = datetime.timedelta(
-                *{k: int(v) for k, v in match.groupdict().items()}
+                **{k: int(v) for k, v in match.groupdict().items()}
             )
             max_runtime = datetime.timedelta(seconds=partition_info["max_runtime"])
             assert runtime <= max_runtime, "Requested runtime is too long"

--- a/jupyterhub_moss/templates/option_form.html
+++ b/jupyterhub_moss/templates/option_form.html
@@ -107,12 +107,12 @@ window.SLURM_DATA = JSON.parse('{{ jsondata }}');
         name="runtime_simple"
         id="runtime_simple"
       >
-        <option value="01:00:00" selected>1 hour</option>
-        <option value="02:00:00">2 hours</option>
-        <option value="04:00:00">4 hours</option>
-        <option value="06:00:00">6 hours</option>
-        <option value="08:00:00">8 hours</option>
-        <option value="12:00:00">12 hours</option>
+        <option value="1" selected>1 hour</option>
+        <option value="2">2 hours</option>
+        <option value="4">4 hours</option>
+        <option value="6">6 hours</option>
+        <option value="8">8 hours</option>
+        <option value="12">12 hours</option>
       </select>
     </div>
     <h4 style="text-align: center">List of available resources:</h4>
@@ -197,9 +197,9 @@ window.SLURM_DATA = JSON.parse('{{ jsondata }}');
       type="text"
       id="runtime"
       name="runtime"
-      value="01:00:00"
+      value="1:00:00"
       placeholder="hh:mm:ss"
-      pattern="(([0-1][0-9])|(2[0-3])):[0-5][0-9]:[0-5][0-9]"
+      pattern="[0-9]+:[0-5][0-9]:[0-5][0-9]"
     />
     <label for="reservation" accesskey="v">
       Reservation <span class="label-extra-info">(--reservation)</span>:


### PR DESCRIPTION
This PR replaces hard-coded checks in the spawner with checks against slurm and partition description information.
It adds a `max_runtime` field (in seconds) to partition information.
This field is used both in the backend validation and in the simple tab in the front-end.
Note: `max_runtime` should be at least 1 hour.

closes #4