### PR TITLE
Set up bump2version and automated releases on tags

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.0.2
+current_version = 1.0.1
 tag = True
 commit = True
 message = Bump to v{new_version}

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,0 +1,8 @@
+[bumpversion]
+current_version = 1.0.2
+tag = True
+commit = True
+message = Bump to v{new_version}
+tag_message = {now:%Y/%m/%d}
+
+[bumpversion:file:jupyterhub_moss/__init__.py]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,36 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - v*
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout 🏷️
+      uses: actions/checkout@v2
+
+    - name: Set up Python 🐍
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.7
+
+    - name: Install dependencies ⚙️
+      run: |
+        python -m pip install --upgrade pip
+        pip install build twine
+
+    - name: Build the package 📦
+      run: python -m build
+
+    - name: Check the package 🧐
+      run: python -m twine check dist/*
+    
+    - name: Release on PyPI 🎉
+      env:
+        TWINE_USERNAME: __token__
+        TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
+      run: python -m twine upload dist/*

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,3 +65,5 @@ This will bump the version, commit the result and tag the current HEAD. You can 
 ```
 git push && git push --tags
 ```
+
+This will trigger a CI job that should release automatically the package on PyPI.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,12 +1,14 @@
 # Contributing to jupyterlab_moss
 
+## Development
+
 The dependencies needed to contribute can be installed by
 
 ```
 pip install .[dev]
 ```
 
-## Linting
+### Linting
 
 [flake8](https://flake8.pycqa.org/en/latest/index.html) is used to lint the code. The config is located in [setup.cfg](./setup.cfg). Linting can be run using
 
@@ -14,7 +16,7 @@ pip install .[dev]
 flake8 .
 ```
 
-## Formatting
+### Formatting
 
 [black](https://black.readthedocs.io/en/stable/) is used to format Python files. Most editors can be configured to format on save but you can run the formatting manually using
 
@@ -22,14 +24,9 @@ flake8 .
 black .
 ```
 
-## CI
+### CI
 
 The CI will check that the lint check passes and that all files are correctly formatted (using `black --check .`). Before commiting, be sure to run `flake8` and `black` to ensure CI passes.
-
-
-## Build package from source
-
-From the project directory, run: `python3 -m build` to generate the wheel and tarball in `dist/`
 
 ## Generate the spawn page locally
 
@@ -48,4 +45,23 @@ c = get_config()
 set_config(c)
 c.JupyterHub.spawner_class = MOckSlurmSpawner
 c.MOckSlurmSpawner.partitions = {...}
+```
+
+## Release
+
+### Build package from source
+
+From the project directory, run: `python3 -m build` to generate the wheel and tarball in `dist/`
+
+
+### Make a new release
+
+First, be sure to be up to date with the remote `main` and that your working tree is clean. Then, run `bumpversion`:
+```
+bumpversion [major|minor|patch]
+```
+
+This will bump the version, commit the result and tag the current HEAD. You can then push the commit and the tag to the repo:
+```
+git push && git push --tags
 ```

--- a/jupyterhub_moss/__init__.py
+++ b/jupyterhub_moss/__init__.py
@@ -4,7 +4,7 @@ from .utils import local_path as _local_path
 from .spawner import MOSlurmSpawner
 from .auth import KeycloakAuthenticator  # noqa: F401
 
-version = "1.0.2"
+version = "1.0.1"
 
 STATIC_FORM_REGEX = r"/form/(.*)"
 STATIC_FORM_PATH = _local_path("form")

--- a/jupyterhub_moss/__init__.py
+++ b/jupyterhub_moss/__init__.py
@@ -4,7 +4,7 @@ from .utils import local_path as _local_path
 from .spawner import MOSlurmSpawner
 from .auth import KeycloakAuthenticator  # noqa: F401
 
-version = "1.0.2a0"
+version = "1.0.2"
 
 STATIC_FORM_REGEX = r"/form/(.*)"
 STATIC_FORM_PATH = _local_path("form")

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,6 +32,7 @@ install_requires =
 [options.extras_require]
 dev =
     build
+    bump2version
     flake8
     black
 


### PR DESCRIPTION
If we use this release process, we have to drop the `a0` at the end of the version as these would conflict with the bump2version config.