### PR TITLE
Replace `jupyterlab` query parameter with `default_url`

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,8 +176,10 @@ The following query argument is required:
 
 The following optional query arguments are available:
 
+- `default_url`: The URL to open the Jupyter environment with: use `/lab` to
+  start [JupyterLab](https://jupyterlab.readthedocs.io/en/stable/) or use
+  [JupyterLab URLs](https://jupyterlab.readthedocs.io/en/stable/user/urls.html)
 - `environment_path`: Path to Python environment bin/ used to start Jupyter
-- `jupyterlab`: Set to `true` to start with JupyterLab
 - `mem`: Total amount of memory per node
   ([`--mem`](https://slurm.schedmd.com/sbatch.html#OPT_mem))
 - `ngpus`: Number of GPUs

--- a/README.md
+++ b/README.md
@@ -176,22 +176,28 @@ The following query argument is required:
 
 The following optional query arguments are available:
 
-- `default_url`: The URL to open the Jupyter environment with: use `/lab` to
-  start [JupyterLab](https://jupyterlab.readthedocs.io/en/stable/) or use
-  [JupyterLab URLs](https://jupyterlab.readthedocs.io/en/stable/user/urls.html)
-- `environment_path`: Path to Python environment bin/ used to start Jupyter
-- `mem`: Total amount of memory per node
-  ([`--mem`](https://slurm.schedmd.com/sbatch.html#OPT_mem))
-- `ngpus`: Number of GPUs
-  ([`--gres:<gpu>:`](https://slurm.schedmd.com/sbatch.html#OPT_gres))
-- `nprocs`: Number of CPUs per task
-  ([`--cpus-per-task`](https://slurm.schedmd.com/sbatch.html#OPT_cpus-per-task))
-- `options`: Extra SLURM options
-- `output`: Set to `true` to save logs to `slurm-*.out` files.
-- `reservation`: SLURM reservation name
-  ([`--reservation`](https://slurm.schedmd.com/sbatch.html#OPT_reservation))
-- `runtime`: Job duration as hh:mm:ss
-  ([`--time`](https://slurm.schedmd.com/sbatch.html#OPT_time))
+- SLURM configuration:
+
+  - `mem`: Total amount of memory per node
+    ([`--mem`](https://slurm.schedmd.com/sbatch.html#OPT_mem))
+  - `ngpus`: Number of GPUs
+    ([`--gres:<gpu>:`](https://slurm.schedmd.com/sbatch.html#OPT_gres))
+  - `nprocs`: Number of CPUs per task
+    ([`--cpus-per-task`](https://slurm.schedmd.com/sbatch.html#OPT_cpus-per-task))
+  - `options`: Extra SLURM options
+  - `output`: Set to `true` to save logs to `slurm-*.out` files.
+  - `reservation`: SLURM reservation name
+    ([`--reservation`](https://slurm.schedmd.com/sbatch.html#OPT_reservation))
+  - `runtime`: Job duration as hh:mm:ss
+    ([`--time`](https://slurm.schedmd.com/sbatch.html#OPT_time))
+
+- Jupyter(Lab) configuration:
+  - `default_url`: The URL to open the Jupyter environment with: use `/lab` to
+    start [JupyterLab](https://jupyterlab.readthedocs.io/en/stable/) or use
+    [JupyterLab URLs](https://jupyterlab.readthedocs.io/en/stable/user/urls.html)
+  - `environment_path`: Path to Python environment bin/ used to start Jupyter
+  - `root_dir`: The path of the "root" folder browsable from Jupyter(Lab)
+    (user's home directory if not provided)
 
 ## Development
 

--- a/jupyterhub_moss/form/option_form.js
+++ b/jupyterhub_moss/form/option_form.js
@@ -381,7 +381,7 @@ function storeConfigToLocalStorage() {
     'mem_input',
     'ngpus',
     'runtime',
-    'jupyterlab',
+    'default_url',
     'output',
     'reservation',
     'options',
@@ -457,7 +457,7 @@ function restoreConfigFromLocalStorage() {
     }
     runtimeSelect.value = config['simple']['runtime'];
     runtimeSelect.dispatchEvent(new Event('change'));
-    jupyterlabSimpleElem.checked = config['fields']['jupyterlab'];
+    jupyterlabSimpleElem.checked = config['fields']['default_url'];
     jupyterlabSimpleElem.dispatchEvent(new Event('change'));
   }
 
@@ -470,8 +470,8 @@ document.addEventListener('DOMContentLoaded', () => {
 
   const nprocsElem = document.getElementById('nprocs');
   const ngpusElem = document.getElementById('ngpus');
-  const jupyterlabElem = document.getElementById('jupyterlab');
   const runtimeElem = document.getElementById('runtime');
+  const default_url = document.getElementById('default_url');
   const environmentAddRadio = document.getElementById('environment_add_radio');
   const environmentAddName = document.getElementById('environment_add_name');
   const environmentAddPath = document.getElementById('environment_add_path');
@@ -502,12 +502,11 @@ document.addEventListener('DOMContentLoaded', () => {
       ngpusElem.value = e.target.value;
     });
   });
-  // JupyterLab
-  document
-    .getElementById('jupyterlab_simple')
-    .addEventListener('change', (e) => {
-      jupyterlabElem.checked = e.target.checked;
-    });
+  // JupyterLab using default_url field
+  document.getElementById('jupyterlab_simple').addEventListener(
+    'change', e => {
+      default_url.checked = e.target.checked;
+  });
   // Runtime
   document.getElementById('runtime_simple').addEventListener('change', (e) => {
     runtimeElem.value = `${e.target.value}:00:00`;

--- a/jupyterhub_moss/spawner.py
+++ b/jupyterhub_moss/spawner.py
@@ -156,10 +156,10 @@ class MOSlurmSpawner(SlurmSpawner):
         "mem": str,
         "reservation": str,
         "ngpus": int,
-        "jupyterlab": lambda v: v == "true",
         "options": lambda v: v.strip(),
         "output": lambda v: v == "true",
         "environment_path": str,
+        "default_url": str,
     }
 
     _RUNTIME_REGEXP = re.compile(
@@ -208,6 +208,11 @@ class MOSlurmSpawner(SlurmSpawner):
         if "environment_path" in options and "\n" in options["environment_path"]:
             raise AssertionError("Error in environment_path")
 
+        if "default_url" in options:
+            default_url = options["default_url"]
+            if default_url and not default_url.startswith("/"):
+                raise AssertionError("Must start with /")
+
     def options_from_form(self, formdata: Dict[str, List[str]]) -> Dict[str, str]:
         """Parse the form and add options to the SLURM job script"""
         # Convert expected input from List[str] to appropriate type
@@ -235,8 +240,8 @@ class MOSlurmSpawner(SlurmSpawner):
         ):
             options["exclusive"] = True
 
-        # Specific handling of jupyterlab
-        self.default_url = "/lab" if options.get("jupyterlab", False) else ""
+        # Specific handling of landing URL (e.g., to start jupyterlab)
+        self.default_url = options.get("default_url", "")
 
         # Specific handling of ngpus as gres
         if options.get("ngpus", 0) > 0:

--- a/jupyterhub_moss/spawner.py
+++ b/jupyterhub_moss/spawner.py
@@ -160,6 +160,7 @@ class MOSlurmSpawner(SlurmSpawner):
         "output": lambda v: v == "true",
         "environment_path": str,
         "default_url": str,
+        "root_dir": str,
     }
 
     _RUNTIME_REGEXP = re.compile(
@@ -213,6 +214,9 @@ class MOSlurmSpawner(SlurmSpawner):
             if default_url and not default_url.startswith("/"):
                 raise AssertionError("Must start with /")
 
+        if "root_dir" in options and "\n" in options["root_dir"]:
+            raise AssertionError("Error in root_dir")
+
     def options_from_form(self, formdata: Dict[str, List[str]]) -> Dict[str, str]:
         """Parse the form and add options to the SLURM job script"""
         # Convert expected input from List[str] to appropriate type
@@ -242,6 +246,9 @@ class MOSlurmSpawner(SlurmSpawner):
 
         # Specific handling of landing URL (e.g., to start jupyterlab)
         self.default_url = options.get("default_url", "")
+
+        if "root_dir" in options:
+            self.notebook_dir = options["root_dir"]
 
         # Specific handling of ngpus as gres
         if options.get("ngpus", 0) > 0:

--- a/jupyterhub_moss/templates/option_form.html
+++ b/jupyterhub_moss/templates/option_form.html
@@ -221,12 +221,12 @@ window.SLURM_DATA = JSON.parse('{{ jsondata }}');
       placeholder="hh:mm:ss"
       pattern="[0-9]+:[0-5][0-9]:[0-5][0-9]"
     />
-    <label for="jupyterlab">Launch JupyterLab:</label>
+    <label for="default_url">Launch JupyterLab:</label>
     <input
       type="checkbox"
-      id="jupyterlab"
-      name="jupyterlab"
-      value="true"
+      id="default_url"
+      name="default_url"
+      value="/lab"
       checked
     />
     <label>Jupyter environment:</label>


### PR DESCRIPTION
This does not provide any functionality from the spawn page, but it allows to open a file/folder directly by passing `default_url` as a GET query argument and to select the default folder with the `root_dir` query parameter.

Note: the path used in `default_dir` is relative to the `notebook_dir` folder.

This allows to create URLs which points to a specific folder and open a notebook upon start-up.