### PR TITLE
Disable slurm logs by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ The following optional query arguments are available:
 - `nprocs`: Number of CPUs per task (``--cpus-per-task``)
 - `ntasks`: Number of tasks per node (``--ntasks-per-node``)
 - `options`: Extra SLURM options
+- `output`: Set to `true` to save logs to `slurm-*.out` files.
 - `reservation`: SLURM reservation name (``--reservation``)
 - `runtime`: Job duration as hh:mm:ss (``--time``)
 

--- a/jupyterhub_moss/batch_script.sh
+++ b/jupyterhub_moss/batch_script.sh
@@ -11,6 +11,7 @@
 {% endif %}{% if nnodes     %}#SBATCH --nodes={{nnodes}}
 {% endif %}{% if ntasks     %}#SBATCH --ntasks-per-node={{ntasks}}
 {% endif %}{% if exclusive  %}#SBATCH --exclusive
+{% endif %}{% if output is not defined or not output %}#SBATCH --output=/dev/null
 {% endif %}{% if options %}#SBATCH {{options}}
 {% endif %}
 

--- a/jupyterhub_moss/batch_script.sh
+++ b/jupyterhub_moss/batch_script.sh
@@ -11,7 +11,7 @@
 {% endif %}{% if nnodes     %}#SBATCH --nodes={{nnodes}}
 {% endif %}{% if ntasks     %}#SBATCH --ntasks-per-node={{ntasks}}
 {% endif %}{% if exclusive  %}#SBATCH --exclusive
-{% endif %}{% if output is not defined or not output %}#SBATCH --output=/dev/null
+{% endif %}{% if not output %}#SBATCH --output=/dev/null
 {% endif %}{% if options %}#SBATCH {{options}}
 {% endif %}
 

--- a/jupyterhub_moss/form/option_form.js
+++ b/jupyterhub_moss/form/option_form.js
@@ -95,7 +95,7 @@ function storeConfigToLocalStorage() {
 
   // Retrieve form fields to store
   const fieldNames = ['partition', 'nprocs', 'ngpus', 'runtime', 'jupyterlab',
-                      'exclusive', 'reservation', 'nnodes', 'ntasks', 'options'];
+                      'exclusive', 'output', 'reservation', 'nnodes', 'ntasks', 'options'];
   const fields = {}
   for (const name of fieldNames) {
     const elem = document.getElementById(name);

--- a/jupyterhub_moss/spawner.py
+++ b/jupyterhub_moss/spawner.py
@@ -111,6 +111,7 @@ class MOSlurmSpawner(SlurmSpawner):
         "ngpus": int,
         "jupyterlab": lambda v: v == "true",
         "options": lambda v: v.strip(),
+        "output": lambda v: v == "true",
     }
 
     _RUNTIME_REGEXP = re.compile(

--- a/jupyterhub_moss/templates/option_form.html
+++ b/jupyterhub_moss/templates/option_form.html
@@ -190,11 +190,18 @@ window.SLURM_DATA = JSON.parse('{{ jsondata }}');
       value="true"
     />
     <hr />
-   <label for="exclusive">Exclusive <span class="label-extra-info">(--exclusive)</span>:</label>
+    <label for="exclusive">Exclusive <span class="label-extra-info">(--exclusive)</span>:</label>
     <input
       type="checkbox"
       id="exclusive"
       name="exclusive"
+      value="true"
+    />
+    <label for="output">Save session logs <span class="label-extra-info">to slurm-*.out</span>:</label>
+    <input
+      type="checkbox"
+      id="output"
+      name="output"
       value="true"
     />
     <label for="reservation" accesskey="v">


### PR DESCRIPTION
Redirect logs to `/dev/null` by default and add a toggle in the advance tab to enable log again as before in `slurm-*.out` files.