### PR TITLE
Add a field to provide extra SLURM options

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ The following optional query arguments are available:
 - `nnodes`: Number of nodes (``--nodes``)
 - `nprocs`: Number of CPUs per task (``--cpus-per-task``)
 - `ntasks`: Number of tasks per node (``--ntasks-per-node``)
+- `options`: Extra SLURM options
 - `reservation`: SLURM reservation name (``--reservation``)
 - `runtime`: Job duration as hh:mm:ss (``--time``)
 

--- a/jupyterhub_moss/batch_script.sh
+++ b/jupyterhub_moss/batch_script.sh
@@ -11,6 +11,7 @@
 {% endif %}{% if nnodes     %}#SBATCH --nodes={{nnodes}}
 {% endif %}{% if ntasks     %}#SBATCH --ntasks-per-node={{ntasks}}
 {% endif %}{% if exclusive  %}#SBATCH --exclusive
+{% endif %}{% if options %}#SBATCH {{options}}
 {% endif %}
 
 set -euo pipefail

--- a/jupyterhub_moss/form/option_form.js
+++ b/jupyterhub_moss/form/option_form.js
@@ -95,7 +95,7 @@ function storeConfigToLocalStorage() {
 
   // Retrieve form fields to store
   const fieldNames = ['partition', 'nprocs', 'ngpus', 'runtime', 'jupyterlab',
-                      'exclusive', 'reservation', 'nnodes', 'ntasks'];
+                      'exclusive', 'reservation', 'nnodes', 'ntasks', 'options'];
   const fields = {}
   for (const name of fieldNames) {
     const elem = document.getElementById(name);

--- a/jupyterhub_moss/spawner.py
+++ b/jupyterhub_moss/spawner.py
@@ -110,6 +110,7 @@ class MOSlurmSpawner(SlurmSpawner):
         "exclusive": lambda v: v == "true",
         "ngpus": int,
         "jupyterlab": lambda v: v == "true",
+        "options": lambda v: v.strip(),
     }
 
     _RUNTIME_REGEXP = re.compile(
@@ -153,6 +154,9 @@ class MOSlurmSpawner(SlurmSpawner):
             and not 0 <= options["ngpus"] <= partition_info["max_ngpus"]
         ):
             raise AssertionError("Error in number of GPUs")
+
+        if "options" in options and "\n" in options["options"]:
+            raise AssertionError("Error in extra options")
 
     def options_from_form(self, formdata: Dict[str, List[str]]) -> Dict[str, str]:
         """Parse the form and add options to the SLURM job script"""

--- a/jupyterhub_moss/templates/option_form.html
+++ b/jupyterhub_moss/templates/option_form.html
@@ -190,6 +190,13 @@ window.SLURM_DATA = JSON.parse('{{ jsondata }}');
       value="true"
     />
     <hr />
+   <label for="exclusive">Exclusive <span class="label-extra-info">(--exclusive)</span>:</label>
+    <input
+      type="checkbox"
+      id="exclusive"
+      name="exclusive"
+      value="true"
+    />
     <label for="reservation" accesskey="v">
       Reservation <span class="label-extra-info">(--reservation)</span>:
     </label>
@@ -209,7 +216,7 @@ window.SLURM_DATA = JSON.parse('{{ jsondata }}');
       value="1"
     />
     <label for="ntasks" accesskey="t">
-      Number of tasks per node<span class="label-extra-info">(--ntasks-per-node)</span>:
+      Number of tasks per node <span class="label-extra-info">(--ntasks-per-node)</span>:
     </label>
     <input
       type="number"
@@ -218,12 +225,14 @@ window.SLURM_DATA = JSON.parse('{{ jsondata }}');
       min="1"
       value="1"
     />
-   <label for="exclusive">Exclusive <span class="label-extra-info">(--exclusive)</span>:</label>
+    <label for="options">
+      Extra options <span class="label-extra-info">(space-separated)</span>:
+    </label>
     <input
-      type="checkbox"
-      id="exclusive"
-      name="exclusive"
-      value="true"
+      type="text"
+      id="options"
+      name="options"
+      placeholder="--option1=v1 --option2=v2"
     />
     </div>
 


### PR DESCRIPTION
This PR includes PR #22.

It adds a field to provide custom SLURM options (e.g., `--cores-per-socket`).
By placing `options` at the end of the `#SBATCH` list, it also overrides whatever is defined in the other field of the form.

closes #19