### PR TITLE
Update information retrieved from SLURM

### DIFF
--- a/jupyterhub_moss/spawner.py
+++ b/jupyterhub_moss/spawner.py
@@ -75,9 +75,10 @@ class MOSlurmSpawner(SlurmSpawner):
                 "-o",
                 "%R %T %D",
             ]
-        )
+        ).decode("utf-8")
         for line in output.splitlines():
-            partition, state, count = line.split()
+            partition, state, count_string = line.split()
+            count = int(count_string)
             info = slurm_info[partition]
             if state in ("idle", "mixed"):
                 info[state] = count
@@ -92,10 +93,10 @@ class MOSlurmSpawner(SlurmSpawner):
                 "-o",
                 "%R %C",
             ]
-        )
+        ).decode("utf-8")
         for line in output.splitlines():
             partition, cpus_info = line.split()
-            nidle_cpus = int(cpus_info.split('/')[1])
+            nidle_cpus = int(cpus_info.split("/")[1])
             info = slurm_info[partition]
             if info["max_idle_cpus"] < nidle_cpus:
                 info["max_idle_cpus"] = nidle_cpus

--- a/jupyterhub_moss/templates/option_form.html
+++ b/jupyterhub_moss/templates/option_form.html
@@ -126,20 +126,22 @@ window.SLURM_DATA = JSON.parse('{{ jsondata }}');
     <h4 style="text-align: center">List of available resources:</h4>
     <table width="100%" border="1" style="text-align: center">
       <tr style="text-align: center; background-color: orange">
-        <th style="text-align: center" colspan="4">Current Status</th>
+        <th style="text-align: center" colspan="5">Current Status</th>
       </tr>
 
       <tr style="text-align: center; background-color: gold">
-        <th width="25%" style="text-align: center">Partition</th>
-        <th width="25%" style="text-align: center"># nodes</th>
-        <th width="25%" style="text-align: center"># partly avail.</th>
-        <th width="25%" style="text-align: center"># fully avail.</th>
+        <th width="20%" style="text-align: center">Partition</th>
+        <th width="20%" style="text-align: center">Max CPUs/node</th>
+        <th width="20%" style="text-align: center"># nodes</th>
+        <th width="20%" style="text-align: center"># partly avail.</th>
+        <th width="20%" style="text-align: center"># fully avail.</th>
       </tr>
 
       {% for name, partition in partitions.items() %}
       {% if partition.simple %}
       <tr>
         <th style="text-align: center">{{ name }}</th>
+        <td>{{ partition.max_idle_cpus }}</td>
         <td>{{ partition.max_nnodes }}</td>
         <td>{{ partition.nnodes_mixed }}</td>
         <td>{{ partition.nnodes_idle }}</td>
@@ -256,17 +258,19 @@ window.SLURM_DATA = JSON.parse('{{ jsondata }}');
     <h4 style="text-align: center">List of available resources:</h4>
     <table width="100%" border="1" style="text-align: center">
       <tr style="text-align: center; background-color: orange">
-        <th style="text-align: center" colspan="4">Current Status</th>
+        <th style="text-align: center" colspan="5">Current Status</th>
       </tr>
       <tr style="text-align: center; background-color: gold">
-        <th width="25%" style="text-align: center">Partition</th>
-        <th width="25%" style="text-align: center"># nodes</th>
-        <th width="25%" style="text-align: center"># partly avail.</th>
-        <th width="25%" style="text-align: center"># fully avail.</th>
+        <th width="20%" style="text-align: center">Partition</th>
+        <th width="20%" style="text-align: center">Max CPUs/node</th>
+        <th width="20%" style="text-align: center"># nodes</th>
+        <th width="20%" style="text-align: center"># partly avail.</th>
+        <th width="20%" style="text-align: center"># fully avail.</th>
       </tr>
       {% for name, partition in partitions.items() %}
       <tr>
         <th style="text-align: center">{{ name }}</th>
+        <td>{{ partition.max_idle_cpus }}</td>
         <td>{{ partition.max_nnodes }}</td>
         <td>{{ partition.nnodes_mixed }}</td>
         <td>{{ partition.nnodes_idle }}</td>

--- a/jupyterhub_moss/templates/option_form.html
+++ b/jupyterhub_moss/templates/option_form.html
@@ -126,13 +126,14 @@ window.SLURM_DATA = JSON.parse('{{ jsondata }}');
     <h4 style="text-align: center">List of available resources:</h4>
     <table width="100%" border="1" style="text-align: center">
       <tr style="text-align: center; background-color: orange">
-        <th style="text-align: center" colspan="6">Current Status</th>
+        <th style="text-align: center" colspan="4">Current Status</th>
       </tr>
 
       <tr style="text-align: center; background-color: gold">
-        <th style="text-align: center">Partition</th>
-        <th style="text-align: center"># nodes</th>
-        <th style="text-align: center"># avail</th>
+        <th width="25%" style="text-align: center">Partition</th>
+        <th width="25%" style="text-align: center"># nodes</th>
+        <th width="25%" style="text-align: center"># partly avail.</th>
+        <th width="25%" style="text-align: center"># fully avail.</th>
       </tr>
 
       {% for name, partition in partitions.items() %}
@@ -140,6 +141,7 @@ window.SLURM_DATA = JSON.parse('{{ jsondata }}');
       <tr>
         <th style="text-align: center">{{ name }}</th>
         <td>{{ partition.max_nnodes }}</td>
+        <td>{{ partition.nnodes_mixed }}</td>
         <td>{{ partition.nnodes_idle }}</td>
       </tr>
       {% endif %}
@@ -254,17 +256,19 @@ window.SLURM_DATA = JSON.parse('{{ jsondata }}');
     <h4 style="text-align: center">List of available resources:</h4>
     <table width="100%" border="1" style="text-align: center">
       <tr style="text-align: center; background-color: orange">
-        <th style="text-align: center" colspan="6">Current Status</th>
+        <th style="text-align: center" colspan="4">Current Status</th>
       </tr>
       <tr style="text-align: center; background-color: gold">
-        <th style="text-align: center">Partition</th>
-        <th style="text-align: center"># nodes</th>
-        <th style="text-align: center"># avail</th>
+        <th width="25%" style="text-align: center">Partition</th>
+        <th width="25%" style="text-align: center"># nodes</th>
+        <th width="25%" style="text-align: center"># partly avail.</th>
+        <th width="25%" style="text-align: center"># fully avail.</th>
       </tr>
       {% for name, partition in partitions.items() %}
       <tr>
         <th style="text-align: center">{{ name }}</th>
         <td>{{ partition.max_nnodes }}</td>
+        <td>{{ partition.nnodes_mixed }}</td>
         <td>{{ partition.nnodes_idle }}</td>
       </tr>
       {% endfor %}


### PR DESCRIPTION
This PR aims at improving the way to retrieve information from `sinfo` and the "Current Status" array by adding for each partition:
- the number of partly allocated nodes (`mixed` state).
- the maximum number of CPUs on one node available, but it is maybe too much since other factors can prevent the resource allocation (other jobs already in the queue and available memory on the node), so I'll probably remove it.

There is also an issue in that what is displayed does not correspond to current state but to some older state.
It needs to figure out when this is updated.

closes #17