### PR TITLE
Fixed js/css cache issue when updating jupyterhub_moss

### DIFF
--- a/jupyterhub_moss/spawner.py
+++ b/jupyterhub_moss/spawner.py
@@ -10,11 +10,16 @@ import traitlets
 from subprocess import check_output
 from jinja2 import Environment, FileSystemLoader
 
-from .utils import local_path
+from .utils import local_path, file_hash
 
 
 TEMPLATE_PATH = local_path("templates")
 
+# Compute resources hash once at start-up
+RESOURCES_HASH = {
+    name: file_hash(local_path(os.path.join("form", name)))
+    for name in ("option_form.css", "option_form.js")
+}
 
 with open(local_path("batch_script.sh")) as f:
     BATCH_SCRIPT = f.read()
@@ -94,6 +99,8 @@ class MOSlurmSpawner(SlurmSpawner):
 
         form_template = self.jinja_env.get_template("option_form.html")
         return form_template.render(
+            hash_option_form_css=RESOURCES_HASH["option_form.css"],
+            hash_option_form_js=RESOURCES_HASH["option_form.js"],
             partitions=partitions,
             default_partition=default_partition,
             jsondata=jsondata,

--- a/jupyterhub_moss/templates/option_form.html
+++ b/jupyterhub_moss/templates/option_form.html
@@ -1,9 +1,9 @@
-<link href="/form/option_form.css" rel="stylesheet" />
+<link href="/form/option_form.css?v={{hash_option_form_css}}" rel="stylesheet" />
 <script>
 window.SLURM_DATA = JSON.parse('{{ jsondata }}');
 </script>
 <script
-  src="/form/option_form.js"
+  src="/form/option_form.js?v={{hash_option_form_js}}"
   type="text/javascript"
   charset="utf-8"
 ></script>

--- a/jupyterhub_moss/utils.py
+++ b/jupyterhub_moss/utils.py
@@ -1,6 +1,12 @@
+import hashlib
 import os.path
 
 
 def local_path(path: str) -> str:
     current_dir = os.path.dirname(__file__)
     return os.path.abspath(os.path.join(current_dir, path))
+
+
+def file_hash(filename: str) -> str:
+    with open(filename, "rb") as f:
+        return hashlib.sha256(f.read()).hexdigest()


### PR DESCRIPTION
This PR adds cache busting for js and css to avoid issues when updating template/css/js with what is cached in the brower.
Hashes are computed once at start-up, so jupyterhub needs to be restarted for each change in the js css files.
Anyway as it is now, the html page seems to be generate once and needs restart when the template is changed... This needs to be sorted out, but in another PR.

Thanks @axelboc for the hint.

closes #30