### PR TITLE
Fixed spawn page refresh

### DIFF
--- a/jupyterhub_moss/spawner.py
+++ b/jupyterhub_moss/spawner.py
@@ -54,7 +54,7 @@ class MOSlurmSpawner(SlurmSpawner):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.options_form = self._get_options_form
+        self.options_form = self.create_options_form
 
     def _get_slurm_info(self):
         """Returns information about partitions from slurm"""
@@ -72,7 +72,7 @@ class MOSlurmSpawner(SlurmSpawner):
         return slurm_info
 
     @staticmethod
-    def _get_options_form(spawner):
+    def create_options_form(spawner):
         """Create a form for the user to choose the configuration for the SLURM job"""
         slurm_info = spawner._get_slurm_info()
 

--- a/jupyterhub_moss/spawner.py
+++ b/jupyterhub_moss/spawner.py
@@ -45,12 +45,16 @@ class MOSlurmSpawner(SlurmSpawner):
         help="Information on supported partitions",
     ).tag(config=True)
 
-    jinja_env = Environment(
+    FORM_TEMPLATE = Environment(
         loader=FileSystemLoader(TEMPLATE_PATH),
         autoescape=False,
         trim_blocks=True,
         lstrip_blocks=True,
-    )
+    ).get_template("option_form.html")
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.options_form = self._get_options_form
 
     def _get_slurm_info(self):
         """Returns information about partitions from slurm"""
@@ -67,15 +71,15 @@ class MOSlurmSpawner(SlurmSpawner):
                 info["idle"] += 1
         return slurm_info
 
-    def _options_form_default(self):
+    @staticmethod
+    def _get_options_form(spawner):
         """Create a form for the user to choose the configuration for the SLURM job"""
-
-        slurm_info = self._get_slurm_info()
+        slurm_info = spawner._get_slurm_info()
 
         # Combine all partition info as a dict
         partitions = {}
         default_partition = None
-        for name, info in self.partitions.items():
+        for name, info in spawner.partitions.items():
             partitions[name] = {
                 "max_nnodes": slurm_info[name]["nodes"],
                 "nnodes_idle": slurm_info[name]["idle"],
@@ -92,8 +96,7 @@ class MOSlurmSpawner(SlurmSpawner):
             }
         )
 
-        form_template = self.jinja_env.get_template("option_form.html")
-        return form_template.render(
+        return spawner.FORM_TEMPLATE.render(
             partitions=partitions,
             default_partition=default_partition,
             jsondata=jsondata,

--- a/jupyterhub_moss/templates/option_form.html
+++ b/jupyterhub_moss/templates/option_form.html
@@ -1,9 +1,9 @@
-<link href="/form/option_form.css" rel="stylesheet" />
+<link href="/hub/form/option_form.css" rel="stylesheet" />
 <script>
 window.SLURM_DATA = JSON.parse('{{ jsondata }}');
 </script>
 <script
-  src="/form/option_form.js"
+  src="/hub/form/option_form.js"
   type="text/javascript"
   charset="utf-8"
 ></script>


### PR DESCRIPTION
This PR fixes the update of the spawn page by replacing its implementation based on `_options_form_default` that's magically gets called as traitlet default to passing a function as `options_form` value which gets called for each request of the page (while the default value looks to be computed once).

It also adds `/hub` prefix to urls to avoid a redirect of `option_form.[css|js]`

related to #28
closes #32