### PR TITLE
Fixed persistence of simple tab when switching from Advanced to Simple

### DIFF
--- a/jupyterhub_moss/form/option_form.js
+++ b/jupyterhub_moss/form/option_form.js
@@ -210,7 +210,14 @@ document.addEventListener("DOMContentLoaded", () => {
 
   // Reset when returning to simple tab
   document.getElementById('simple_tab_link').addEventListener(
-    'click', resetSpawnForm
+    'click', () => {
+      const config = JSON.parse(window.localStorage.getItem(CONFIG_NAME));
+      if (config !== null && !config['isAdvanced']) {
+        restoreConfigFromLocalStorage();
+      } else {
+        resetSpawnForm();
+      }
+    }
   );
 
   // Update limits when partition is changed


### PR DESCRIPTION
This PR restored persisted config when switching back from advanced to simple tab and the saved config was a simple one.
The storage of the config is still done when the form is submitted and not when switching from simple to advanced tab.

Not sure what to do.
On one side I like the idea of saving the last effectively used config.
On the other hand, this can be a bit miss-leading: one can expect to come back to the simple tab with what was there the last time he show the tab content (which is possible by registering a listener on `advanced_tab_link`).


closes #35