### PR TITLE
Add supports for starting multiple Jupyter environment (including custom ones)

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,9 @@ c.MOSlurmSpawner.partitions = {
         "max_nprocs": 28,                  # Maximum number of CPUs per node
         "max_runtime": 12*3600,            # Maximum time limit in seconds (Must be at least 1hour)
         "simple": True,                    # True to show in Simple tab
-        "venv": "/jupyter_env_path/bin/",  # Path to Python environment bin/ used to start jupyter on the Slurm nodes 
+        "jupyter_environments": {
+            "default": "/jupyter_env_path/bin/",  # Path to Python environment bin/ used to start jupyter on the Slurm nodes
+        },
     },
     "partition_2": {
         "architecture": "ppc64le",
@@ -54,7 +56,9 @@ c.MOSlurmSpawner.partitions = {
         "max_nprocs": 128,
         "max_runtime": 1*3600,
         "simple": True,
-        "venv": "/path/to/jupyter/env/for/partition_2/bin/",
+        "jupyter_environments": {
+            "default": "/path/to/jupyter/env/for/partition_2/bin/",
+        },
     },
     "partition_3": {
         "architecture": "x86_86",
@@ -64,7 +68,9 @@ c.MOSlurmSpawner.partitions = {
         "max_nprocs": 28,
         "max_runtime": 12*3600,
         "simple": False,
-        "venv": "/path/to/jupyter/env/for/partition_3/bin/",
+        "jupyter_environments": {
+            "default": "/path/to/jupyter/env/for/partition_3/bin/",
+        },
     },
 }
 ```
@@ -77,7 +83,10 @@ c.MOSlurmSpawner.partitions = {
 - `max_nprocs`: The maximum number of processors that can be requested for this partition. The spawn page will use this to generate appropriate bounds for the user inputs.
 - `max_runtime`: The maximum job runtime for this partition in seconds. It should be of minimum 1 hour as the _Simple_ tab only display buttons for runtimes greater than 1 hour.
 - `simple`: Whether the partition should be available in the _Simple_ tab. The spawn page that will be generated is organized in a two tabs: a _Simple_ tab with minimal settings that will be enough for most users and an _Advanced_ tab where almost all Slurm job settings can be set. Some partitions can be hidden from the _Simple_ tab with setting `simple` to `False`.
-- `venv`: Path to Python environment bin/ used to start jupyter on the Slurm nodes. **jupyterhub_moss** expects that a virtual environment is used to start jupyter. The path of this venv is set in the `venv` field and can be changed according to the partition. If there is only one venv, simply set the same path to all partitions.
+- `jupyter_environments`: Mapping of selection option name to path to Python environment bin/ used to start jupyter on the Slurm nodes.
+  **jupyterhub_moss** expects that a virtual (or conda) environment is used to start jupyter.
+  The path of this venv is set in the `jupyter_environments` field and can be changed according to the partition.
+  If there is only one venv, simply use the same path to all partitions.
 
 ### Spawn page
 
@@ -109,6 +118,7 @@ The following query argument is required:
 
 The following optional query arguments are available:
 
+- `environment_path`: Path to Python environment bin/ used to start jupyter
 - `exclusive`: Set to `true` for exclusive node usage (``--exclusive``)
 - `jupyterlab`: Set to `true` to start with JupyterLab
 - `ngpus`: Number of GPUs (``--gres:<gpu>:``)

--- a/README.md
+++ b/README.md
@@ -45,7 +45,10 @@ c.MOSlurmSpawner.partitions = {
         "max_runtime": 12*3600,            # Maximum time limit in seconds (Must be at least 1hour)
         "simple": True,                    # True to show in Simple tab
         "jupyter_environments": {
-            "default": "/jupyter_env_path/bin/",  # Path to Python environment bin/ used to start jupyter on the Slurm nodes
+            "default": {                   # Name of Jupyter environment used to persist it
+                "path": "/env/path/bin/",  # Path to Python environment bin/ used to start jupyter on the Slurm nodes
+                "description": "Default",  # Text displayed for this environment select option
+            },
         },
     },
     "partition_2": {
@@ -57,7 +60,10 @@ c.MOSlurmSpawner.partitions = {
         "max_runtime": 1*3600,
         "simple": True,
         "jupyter_environments": {
-            "default": "/path/to/jupyter/env/for/partition_2/bin/",
+            "default": {
+                "path": "/path/to/jupyter/env/for/partition_2/bin/",
+                "description": "Default",
+            },
         },
     },
     "partition_3": {
@@ -69,7 +75,9 @@ c.MOSlurmSpawner.partitions = {
         "max_runtime": 12*3600,
         "simple": False,
         "jupyter_environments": {
-            "default": "/path/to/jupyter/env/for/partition_3/bin/",
+            "default": {
+                "path": "/path/to/jupyter/env/for/partition_3/bin/",
+                "description": "Partition 3 default",
         },
     },
 }

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ The following query argument is required:
 
 The following optional query arguments are available:
 
-- `environment_path`: Path to Python environment bin/ used to start jupyter
+- `environment_path`: Path to Python environment bin/ used to start Jupyter
 - `exclusive`: Set to `true` for exclusive node usage (``--exclusive``)
 - `jupyterlab`: Set to `true` to start with JupyterLab
 - `ngpus`: Number of GPUs (``--gres:<gpu>:``)

--- a/README.md
+++ b/README.md
@@ -91,10 +91,12 @@ c.MOSlurmSpawner.partitions = {
 - `max_nprocs`: The maximum number of processors that can be requested for this partition. The spawn page will use this to generate appropriate bounds for the user inputs.
 - `max_runtime`: The maximum job runtime for this partition in seconds. It should be of minimum 1 hour as the _Simple_ tab only display buttons for runtimes greater than 1 hour.
 - `simple`: Whether the partition should be available in the _Simple_ tab. The spawn page that will be generated is organized in a two tabs: a _Simple_ tab with minimal settings that will be enough for most users and an _Advanced_ tab where almost all Slurm job settings can be set. Some partitions can be hidden from the _Simple_ tab with setting `simple` to `False`.
-- `jupyter_environments`: Mapping of selection option name to path to Python environment bin/ used to start jupyter on the Slurm nodes.
-  **jupyterhub_moss** expects that a virtual (or conda) environment is used to start jupyter.
-  The path of this venv is set in the `jupyter_environments` field and can be changed according to the partition.
-  If there is only one venv, simply use the same path to all partitions.
+- `jupyter_environments`: Mapping of identifer name to information about Python environment used to run Jupyter on the Slurm nodes.
+  This information is a mapping containing:
+  - `path`: The path to a Python environment bin/ used to start jupyter on the Slurm nodes.
+    **jupyterhub_moss** expects that a virtual (or conda) environment is used to start Jupyter.
+    This path can be changed according the partitions.
+  - `description`: Text used for display in the selection options.
 
 ### Spawn page
 

--- a/demo_jupyterhub_conf.py
+++ b/demo_jupyterhub_conf.py
@@ -35,7 +35,10 @@ c.MOSlurmSpawner.partitions = {
         "max_nprocs": 28,
         "max_runtime": 12 * 3600,
         "simple": True,
-        "venv": "/jupyter_env_path/bin/",
+        "jupyter_environments": {
+            "default": "/default/jupyter_env_path/bin/",
+            "new-x86": "/new-x86/jupyter_env_path/bin/",
+        },
     },
     "partition_2": {
         "architecture": "ppc64le",
@@ -45,7 +48,10 @@ c.MOSlurmSpawner.partitions = {
         "max_nprocs": 128,
         "max_runtime": 1 * 3600,
         "simple": True,
-        "venv": "/path/to/jupyter/env/for/partition_2/bin/",
+        "jupyter_environments": {
+            "default": "/path/to/jupyter/env/for/partition_2/bin/",
+            "new-ppx64le": "/new-ppc64le/jupyter_env_path/bin/",
+        },
     },
     "partition_3": {
         "architecture": "x86_86",
@@ -55,7 +61,10 @@ c.MOSlurmSpawner.partitions = {
         "max_nprocs": 28,
         "max_runtime": 12 * 3600,
         "simple": False,
-        "venv": "/path/to/jupyter/env/for/partition_3/bin/",
+        "jupyter_environments": {
+            "default": "/path/to/jupyter/env/for/partition_3/bin/",
+            "new-x86": "/new-x86/jupyter_env_path/bin/",
+        },
     },
 }
 

--- a/demo_jupyterhub_conf.py
+++ b/demo_jupyterhub_conf.py
@@ -36,8 +36,14 @@ c.MOSlurmSpawner.partitions = {
         "max_runtime": 12 * 3600,
         "simple": True,
         "jupyter_environments": {
-            "default": "/default/jupyter_env_path/bin/",
-            "new-x86": "/new-x86/jupyter_env_path/bin/",
+            "default": {
+                "path": "/default/jupyter_env_path/bin/",
+                "description": "Operating system (default)",
+            },
+            "new-x86": {
+                "path": "/new-x86/jupyter_env_path/bin/",
+                "description": "New environment x86 (latest)"
+            },
         },
     },
     "partition_2": {
@@ -49,8 +55,14 @@ c.MOSlurmSpawner.partitions = {
         "max_runtime": 1 * 3600,
         "simple": True,
         "jupyter_environments": {
-            "default": "/path/to/jupyter/env/for/partition_2/bin/",
-            "new-ppx64le": "/new-ppc64le/jupyter_env_path/bin/",
+            "default": {
+                "path": "/path/to/jupyter/env/for/partition_2/bin/",
+                "description": "Current environment (default)",
+            },
+            "new-ppx64le": {
+                "path": "/new-ppc64le/jupyter_env_path/bin/",
+                "description": "New environment ppc64le (latest)",
+            },
         },
     },
     "partition_3": {
@@ -62,8 +74,14 @@ c.MOSlurmSpawner.partitions = {
         "max_runtime": 12 * 3600,
         "simple": False,
         "jupyter_environments": {
-            "default": "/path/to/jupyter/env/for/partition_3/bin/",
-            "new-x86": "/new-x86/jupyter_env_path/bin/",
+            "default": {
+                "path": "/path/to/jupyter/env/for/partition_3/bin/",
+                "description": "Operating system (default)",
+            },
+            "new-x86": {
+                "path": "/new-x86/jupyter_env_path/bin/",
+                "description": "New environment x86 (latest)"
+            },
         },
     },
 }

--- a/demo_jupyterhub_conf.py
+++ b/demo_jupyterhub_conf.py
@@ -42,7 +42,7 @@ c.MOSlurmSpawner.partitions = {
             },
             "new-x86": {
                 "path": "/new-x86/jupyter_env_path/bin/",
-                "description": "New environment x86 (latest)"
+                "description": "New environment x86 (latest)",
             },
             "latest": {
                 "path": "/latest/jupyter_env_path/bin/",
@@ -88,7 +88,7 @@ c.MOSlurmSpawner.partitions = {
             },
             "new-x86": {
                 "path": "/new-x86/jupyter_env_path/bin/",
-                "description": "New environment x86 (latest)"
+                "description": "New environment x86 (latest)",
             },
         },
     },

--- a/demo_jupyterhub_conf.py
+++ b/demo_jupyterhub_conf.py
@@ -44,6 +44,10 @@ c.MOSlurmSpawner.partitions = {
                 "path": "/new-x86/jupyter_env_path/bin/",
                 "description": "New environment x86 (latest)"
             },
+            "latest": {
+                "path": "/latest/jupyter_env_path/bin/",
+                "description": "Operating system (latest)",
+            },
         },
     },
     "partition_2": {
@@ -58,6 +62,10 @@ c.MOSlurmSpawner.partitions = {
             "default": {
                 "path": "/path/to/jupyter/env/for/partition_2/bin/",
                 "description": "Current environment (default)",
+            },
+            "latest": {
+                "path": "/latest/path/to/jupyter/env/for/partition_2/bin/",
+                "description": "Current environment (latest)",
             },
             "new-ppx64le": {
                 "path": "/new-ppc64le/jupyter_env_path/bin/",

--- a/jupyterhub_moss/form/option_form.css
+++ b/jupyterhub_moss/form/option_form.css
@@ -86,6 +86,7 @@
   justify-self: end;
   width: calc(100% - 2em);
   grid-column: 1 / 3;
+  text-align: left;
 }
 
 @media (max-width: 768px) {

--- a/jupyterhub_moss/form/option_form.css
+++ b/jupyterhub_moss/form/option_form.css
@@ -82,6 +82,12 @@
   grid-column: 1 / 3;
 }
 
+.form-offset-row {
+  justify-self: end;
+  width: calc(100% - 2em);
+  grid-column: 1 / 3;
+}
+
 @media (max-width: 768px) {
   .form-container label {
     grid-column: 1;
@@ -92,5 +98,9 @@
   }
   .form-container input[type="checkbox"] {
     grid-column: 2;
+  }
+
+  .form-offset-row {
+    width: 100%;
   }
 }

--- a/jupyterhub_moss/form/option_form.js
+++ b/jupyterhub_moss/form/option_form.js
@@ -80,6 +80,7 @@ function setSimplePartition(name) {
 function isCustomEnvironment() {
   const environmentElem = document.getElementById('environment');
   const index = environmentElem.selectedIndex;
+
   return index !== -1 && environmentElem.options[index].id === 'environment_custom';
 }
 
@@ -98,9 +99,9 @@ function updateEnvironmentPath() {
   const environmentPathNoteElem = document.getElementById('environment_path_note');
 
   setReadOnly(environmentPathElem, !isCustomEnvironment());
-  setVisible(environmentPathNoteElem, isCustomEnvironment());
   environmentPathElem.style.borderColor = isCustomEnvironment() ? null : 'transparent';
   environmentPathElem.value = getEnvironmentPath();
+  setVisible(environmentPathNoteElem, isCustomEnvironment());
 }
 
 function updateEnvironmentSelect(selection = undefined) {
@@ -115,7 +116,6 @@ function updateEnvironmentSelect(selection = undefined) {
     selection :
     (environmentElem.selectedIndex === -1 ?
       undefined : environmentElem.options[environmentElem.selectedIndex].value);
-  console.log(`selected ${selectionValue}`);
 
   for (const select of [environmentElem, environmentSimpleElem]) {
     // Remove all but custom option
@@ -138,7 +138,6 @@ function updateEnvironmentSelect(selection = undefined) {
     var selectedIndex = 0;
     if (selectionValue !== undefined) {
       for (let index = 0; index < select.length; index++) {
-        console.log(`test ${select.options[index].value}`);
         if (select.options[index].value === selectionValue) {
           selectedIndex = index;
           break;
@@ -262,7 +261,7 @@ function restoreConfigFromLocalStorage() {
   // Restore Jupyter environment
   const environment = config['environment'];
   if (environment === undefined || (environment['isCustom'] && !config['isAdvanced'])) {
-    // Do not restore environment if it was not save or if custom was save for simple tab.
+    // Do not restore environment if it was not saved or if custom was saved for simple tab.
     updateEnvironmentSelect();
   } else {
     if (environment['isCustom']) {

--- a/jupyterhub_moss/form/option_form.js
+++ b/jupyterhub_moss/form/option_form.js
@@ -80,10 +80,12 @@ function setSimplePartition(name) {
 function updateEnvironmentPath() {
   const environmentElem = document.getElementById('environment');
   const environmentPathElem = document.getElementById('environment_path');
+  const environmentPathNoteElem = document.getElementById('environment_path_note');
   const environmentCustomOptionElem = document.getElementById('environment_custom');
 
   const isCustom = environmentElem.options[environmentElem.selectedIndex].id === 'environment_custom';
   setReadOnly(environmentPathElem, !isCustom);
+  setVisible(environmentPathNoteElem, isCustom);
   environmentPathElem.style.borderColor = isCustom ? null : 'transparent';
   environmentPathElem.value = isCustom ? environmentCustomOptionElem.value : environmentElem.value;
 }

--- a/jupyterhub_moss/spawner.py
+++ b/jupyterhub_moss/spawner.py
@@ -39,7 +39,9 @@ class MOSlurmSpawner(SlurmSpawner):
                 "architecture": traitlets.Unicode(),
                 "gpu": traitlets.Unicode(allow_none=True, default_value=None),
                 "simple": traitlets.Bool(),
-                "venv": traitlets.Unicode(),
+                "jupyter_environments": traitlets.Dict(
+                    key_trait=traitlets.Unicode(), value_trait=traitlets.Unicode()
+                ),
                 "max_ngpus": traitlets.Int(),
                 "max_nprocs": traitlets.Int(),
                 "max_runtime": traitlets.Int(),
@@ -88,7 +90,7 @@ class MOSlurmSpawner(SlurmSpawner):
             partitions[name] = {
                 "max_nnodes": slurm_info[name]["nodes"],
                 "nnodes_idle": slurm_info[name]["idle"],
-                **dict((k, v) for k, v in info.items() if k != "venv"),
+                **info
             }
             if info["simple"] and default_partition is None:
                 default_partition = name
@@ -122,6 +124,7 @@ class MOSlurmSpawner(SlurmSpawner):
         "jupyterlab": lambda v: v == "true",
         "options": lambda v: v.strip(),
         "output": lambda v: v == "true",
+        "environment_path": str,
     }
 
     _RUNTIME_REGEXP = re.compile(
@@ -169,6 +172,9 @@ class MOSlurmSpawner(SlurmSpawner):
         if "options" in options and "\n" in options["options"]:
             raise AssertionError("Error in extra options")
 
+        if "environment_path" in options and "\n" in options["environment_path"]:
+            raise AssertionError("Error in environment_path")
+
     def options_from_form(self, formdata: Dict[str, List[str]]) -> Dict[str, str]:
         """Parse the form and add options to the SLURM job script"""
         # Convert expected input from List[str] to appropriate type
@@ -199,7 +205,8 @@ class MOSlurmSpawner(SlurmSpawner):
             options["gres"] = gpu_gres_template.format(options["ngpus"])
 
         # Virtualenv is not activated, we need to provide full path
-        venv_dir = self.partitions[partition]["venv"]
+        default_venv_path = tuple(self.partitions[partition]["jupyter_environments"].values())[0]
+        venv_dir = options.get("environment_path", default_venv_path)
         self.batchspawner_singleuser_cmd = os.path.join(
             venv_dir, "batchspawner-singleuser"
         )

--- a/jupyterhub_moss/spawner.py
+++ b/jupyterhub_moss/spawner.py
@@ -40,7 +40,14 @@ class MOSlurmSpawner(SlurmSpawner):
                 "gpu": traitlets.Unicode(allow_none=True, default_value=None),
                 "simple": traitlets.Bool(),
                 "jupyter_environments": traitlets.Dict(
-                    key_trait=traitlets.Unicode(), value_trait=traitlets.Unicode()
+                    key_trait=traitlets.Unicode(),
+                    value_trait=traitlets.Dict(
+                        key_trait=traitlets.Unicode(),
+                        per_key_traits={
+                            "path": traitlets.Unicode(),
+                            "description": traitlets.Unicode(),
+                        },
+                    ),
                 ),
                 "max_ngpus": traitlets.Int(),
                 "max_nprocs": traitlets.Int(),
@@ -205,10 +212,10 @@ class MOSlurmSpawner(SlurmSpawner):
             options["gres"] = gpu_gres_template.format(options["ngpus"])
 
         # Virtualenv is not activated, we need to provide full path
-        default_venv_path = tuple(
+        default_venv = tuple(
             self.partitions[partition]["jupyter_environments"].values()
         )[0]
-        venv_dir = options.get("environment_path", default_venv_path)
+        venv_dir = options.get("environment_path", default_venv["path"])
         self.batchspawner_singleuser_cmd = os.path.join(
             venv_dir, "batchspawner-singleuser"
         )

--- a/jupyterhub_moss/spawner.py
+++ b/jupyterhub_moss/spawner.py
@@ -90,7 +90,7 @@ class MOSlurmSpawner(SlurmSpawner):
             partitions[name] = {
                 "max_nnodes": slurm_info[name]["nodes"],
                 "nnodes_idle": slurm_info[name]["idle"],
-                **info
+                **info,
             }
             if info["simple"] and default_partition is None:
                 default_partition = name
@@ -205,7 +205,9 @@ class MOSlurmSpawner(SlurmSpawner):
             options["gres"] = gpu_gres_template.format(options["ngpus"])
 
         # Virtualenv is not activated, we need to provide full path
-        default_venv_path = tuple(self.partitions[partition]["jupyter_environments"].values())[0]
+        default_venv_path = tuple(
+            self.partitions[partition]["jupyter_environments"].values()
+        )[0]
         venv_dir = options.get("environment_path", default_venv_path)
         self.batchspawner_singleuser_cmd = os.path.join(
             venv_dir, "batchspawner-singleuser"

--- a/jupyterhub_moss/templates/option_form.html
+++ b/jupyterhub_moss/templates/option_form.html
@@ -104,6 +104,14 @@ window.SLURM_DATA = JSON.parse('{{ jsondata }}');
     </div>
     <p class="subheading">Options</p>
     <div class="form-container">
+      <label for="environment_simple" accesskey="e">
+        Jupyter environment:
+      </label>
+      <select
+        name="environment_simple"
+        id="environment_simple"
+      >
+      </select>
       <label for="jupyterlab_simple">Launch JupyterLab:</label>
       <input
         type="checkbox"
@@ -189,6 +197,22 @@ window.SLURM_DATA = JSON.parse('{{ jsondata }}');
       value="1:00:00"
       placeholder="hh:mm:ss"
       pattern="[0-9]+:[0-5][0-9]:[0-5][0-9]"
+    />
+    <label for="environment" accesskey="e">
+      Jupyter environment:
+    </label>
+    <select
+      name="environment"
+      id="environment"
+    >
+      <option id="environment_custom" value="">Custom...</option>
+    </select>
+    <input
+      type="text"
+      class="form-offset-row"
+      id="environment_path"
+      name="environment_path"
+      placeholder="/path/to/jupyter/environment/bin"
     />
     <label for="jupyterlab">Launch JupyterLab:</label>
     <input

--- a/jupyterhub_moss/templates/option_form.html
+++ b/jupyterhub_moss/templates/option_form.html
@@ -214,6 +214,9 @@ window.SLURM_DATA = JSON.parse('{{ jsondata }}');
       name="environment_path"
       placeholder="/path/to/jupyter/environment/bin"
     />
+    <p id="environment_path_note" class="form-offset-row" hidden>
+      &#9888; The <a href="https://pypi.org/project/batchspawner/">batchspawner</a> package must be installed in this environment.
+    </p>
     <label for="jupyterlab">Launch JupyterLab:</label>
     <input
       type="checkbox"


### PR DESCRIPTION
This PR adds a select field to the form to choose the Jupyter environment to use from a list, and the option to give a custom path from the advanced tab.
The config file and POST request are updated.
The selected Jupyter environment is persisted, yet previous config without it are also supported, thus the version number is not changed.

Simple:
![Screen Shot 2022-01-10 at 15 48 11](https://user-images.githubusercontent.com/9449698/148786723-31b83eb3-1470-46e4-8be8-7619e57693a6.png)

Advanced:
![Screen Shot 2022-01-10 at 15 47 16](https://user-images.githubusercontent.com/9449698/148786758-2ea057b8-21cf-41e6-8740-defafbf8e034.png)

Advanced also provides the option to use a custom env.:
![Screen Shot 2022-01-10 at 15 47 36](https://user-images.githubusercontent.com/9449698/148786786-2d0242f7-a388-494c-8da9-254304355e7b.png)

For the advanced tab, the path of the environment is displayed for information and can be modified when custom is selected.
What is persisted is the name of the env. in the dict rather than the path (except for the custom one) or the select option text. This provides more flexibility to move the env. if need or update the text.
