### PR TITLE
Remove nnodes ntasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,6 @@ The following optional query arguments are available:
 - `exclusive`: Set to `true` for exclusive node usage (``--exclusive``)
 - `jupyterlab`: Set to `true` to start with JupyterLab
 - `ngpus`: Number of GPUs (``--gres:<gpu>:``)
-- `nnodes`: Number of nodes (``--nodes``)
 - `nprocs`: Number of CPUs per task (``--cpus-per-task``)
 - `ntasks`: Number of tasks per node (``--ntasks-per-node``)
 - `options`: Extra SLURM options

--- a/README.md
+++ b/README.md
@@ -133,7 +133,6 @@ The following optional query arguments are available:
 - `jupyterlab`: Set to `true` to start with JupyterLab
 - `ngpus`: Number of GPUs (``--gres:<gpu>:``)
 - `nprocs`: Number of CPUs per task (``--cpus-per-task``)
-- `ntasks`: Number of tasks per node (``--ntasks-per-node``)
 - `options`: Extra SLURM options
 - `output`: Set to `true` to save logs to `slurm-*.out` files.
 - `reservation`: SLURM reservation name (``--reservation``)

--- a/jupyterhub_moss/batch_script.sh
+++ b/jupyterhub_moss/batch_script.sh
@@ -8,7 +8,6 @@
 {% endif %}{% if gres       %}#SBATCH --gres={{gres}}
 {% endif %}{% if nprocs     %}#SBATCH --cpus-per-task={{nprocs}}
 {% endif %}{% if reservation%}#SBATCH --reservation={{reservation}}
-{% endif %}{% if ntasks     %}#SBATCH --ntasks-per-node={{ntasks}}
 {% endif %}{% if exclusive  %}#SBATCH --exclusive
 {% endif %}{% if not output %}#SBATCH --output=/dev/null
 {% endif %}{% if options %}#SBATCH {{options}}

--- a/jupyterhub_moss/batch_script.sh
+++ b/jupyterhub_moss/batch_script.sh
@@ -8,7 +8,6 @@
 {% endif %}{% if gres       %}#SBATCH --gres={{gres}}
 {% endif %}{% if nprocs     %}#SBATCH --cpus-per-task={{nprocs}}
 {% endif %}{% if reservation%}#SBATCH --reservation={{reservation}}
-{% endif %}{% if nnodes     %}#SBATCH --nodes={{nnodes}}
 {% endif %}{% if ntasks     %}#SBATCH --ntasks-per-node={{ntasks}}
 {% endif %}{% if exclusive  %}#SBATCH --exclusive
 {% endif %}{% if not output %}#SBATCH --output=/dev/null

--- a/jupyterhub_moss/form/option_form.js
+++ b/jupyterhub_moss/form/option_form.js
@@ -276,15 +276,11 @@ function setSimplePartition(name) {
 }
 
 function updatePartitionLimits() {
-  const nnodesElem = document.getElementById("nnodes");
   const nprocsElem = document.getElementById("nprocs");
   const ngpusElem = document.getElementById("ngpus");
 
   const partition = document.getElementById('partition').value;
   const info = window.SLURM_DATA.partitions[partition];
-
-  if (nnodesElem.value > info.max_nnodes) nnodesElem.value = info.max_nnodes;
-  nnodesElem.max = info.max_nnodes;
 
   if (nprocsElem.value > info.max_nprocs) nprocsElem.value = info.max_nprocs;
   nprocsElem.max = info.max_nprocs;
@@ -307,7 +303,7 @@ function storeConfigToLocalStorage() {
 
   // Retrieve form fields to store
   const fieldNames = ['partition', 'nprocs', 'ngpus', 'runtime', 'jupyterlab',
-                      'exclusive', 'output', 'reservation', 'nnodes', 'ntasks', 'options'];
+                      'exclusive', 'output', 'reservation', 'ntasks', 'options'];
   const fields = {}
   for (const name of fieldNames) {
     const elem = document.getElementById(name);

--- a/jupyterhub_moss/form/option_form.js
+++ b/jupyterhub_moss/form/option_form.js
@@ -303,7 +303,7 @@ function storeConfigToLocalStorage() {
 
   // Retrieve form fields to store
   const fieldNames = ['partition', 'nprocs', 'ngpus', 'runtime', 'jupyterlab',
-                      'exclusive', 'output', 'reservation', 'ntasks', 'options'];
+                      'exclusive', 'output', 'reservation', 'options'];
   const fields = {}
   for (const name of fieldNames) {
     const elem = document.getElementById(name);

--- a/jupyterhub_moss/form/option_form.js
+++ b/jupyterhub_moss/form/option_form.js
@@ -1,4 +1,4 @@
-const CONFIG_NAME = 'form-config:v1';
+const CONFIG_NAME = 'form-config:v2';
 const CUSTOM_ENV_CONFIG_NAME = 'custom-environment-config:v1';
 
 

--- a/jupyterhub_moss/spawner.py
+++ b/jupyterhub_moss/spawner.py
@@ -142,7 +142,6 @@ class MOSlurmSpawner(SlurmSpawner):
         assert options["partition"] in self.partitions, "Partition is not supported"
 
         partition_info = self.partitions[options["partition"]]
-        slurm_info = self._get_slurm_info()[options["partition"]]
 
         if "runtime" in options:
             match = self._RUNTIME_REGEXP.match(options["runtime"])

--- a/jupyterhub_moss/spawner.py
+++ b/jupyterhub_moss/spawner.py
@@ -124,7 +124,6 @@ class MOSlurmSpawner(SlurmSpawner):
         "runtime": str,
         "nprocs": int,
         "reservation": str,
-        "nnodes": int,
         "ntasks": int,
         "exclusive": lambda v: v == "true",
         "ngpus": int,
@@ -163,9 +162,6 @@ class MOSlurmSpawner(SlurmSpawner):
 
         if "reservation" in options and "\n" in options["reservation"]:
             raise AssertionError("Error in reservation")
-
-        if "nnodes" in options and not 1 <= options["nnodes"] <= slurm_info["nodes"]:
-            raise AssertionError("Error in number of nodes")
 
         if "ntasks" in options and options["ntasks"] < 1:
             raise AssertionError("Error in number ot tasks")

--- a/jupyterhub_moss/spawner.py
+++ b/jupyterhub_moss/spawner.py
@@ -124,7 +124,6 @@ class MOSlurmSpawner(SlurmSpawner):
         "runtime": str,
         "nprocs": int,
         "reservation": str,
-        "ntasks": int,
         "exclusive": lambda v: v == "true",
         "ngpus": int,
         "jupyterlab": lambda v: v == "true",
@@ -162,9 +161,6 @@ class MOSlurmSpawner(SlurmSpawner):
 
         if "reservation" in options and "\n" in options["reservation"]:
             raise AssertionError("Error in reservation")
-
-        if "ntasks" in options and options["ntasks"] < 1:
-            raise AssertionError("Error in number ot tasks")
 
         if (
             "ngpus" in options

--- a/jupyterhub_moss/templates/option_form.html
+++ b/jupyterhub_moss/templates/option_form.html
@@ -265,15 +265,6 @@ window.SLURM_DATA = JSON.parse('{{ jsondata }}');
       name="reservation"
       placeholder="no reservation"
     />
-    <label for="nnodes" accesskey="n">
-      Number of nodes <span class="label-extra-info">(--nodes)</span>:</label>
-    <input
-      type="number"
-      id="nnodes"
-      name="nnodes"
-      min="1"
-      value="1"
-    />
     <label for="ntasks" accesskey="t">
       Number of tasks per node <span class="label-extra-info">(--ntasks-per-node)</span>:
     </label>

--- a/jupyterhub_moss/templates/option_form.html
+++ b/jupyterhub_moss/templates/option_form.html
@@ -265,16 +265,6 @@ window.SLURM_DATA = JSON.parse('{{ jsondata }}');
       name="reservation"
       placeholder="no reservation"
     />
-    <label for="ntasks" accesskey="t">
-      Number of tasks per node <span class="label-extra-info">(--ntasks-per-node)</span>:
-    </label>
-    <input
-      type="number"
-      id="ntasks"
-      name="ntasks"
-      min="1"
-      value="1"
-    />
     <label for="options">
       Extra options <span class="label-extra-info">(space-separated)</span>:
     </label>


### PR DESCRIPTION
This PR removes the number of nodes and number of tasks per node options from the advanced tab.
The persisted config version is updated.

Those options are rarely used and are not relevant for running notebooks, and anyway can be passed as **Extra Options**.