### PR TITLE
Added custom env batchspawner version information + require python >=3.8

### DIFF
--- a/jupyterhub_moss/form/option_form.css
+++ b/jupyterhub_moss/form/option_form.css
@@ -121,8 +121,11 @@
   margin-left: 0.3rem;
 }
 
-.environment-div label,
-.environment-div #environment_add_path {
+.environment-div > div {
+  width: 100%;
+}
+
+.environment-div label {
   flex: 1;
 }
 
@@ -132,7 +135,20 @@
   align-self: baseline;
 }
 
+.environment-add-div {
+  display: flex;
+  align-items: flex-start;
+  width: 100%;
+}
+
+.environment-add-div > * {
+  margin-left: 0.3rem;
+}
+
+#environment_add_path {
+  flex: 1;
+}
+
 #environment_add_button:disabled {
   color: lightgray;
-  height: auto;
 }

--- a/jupyterhub_moss/spawner.py
+++ b/jupyterhub_moss/spawner.py
@@ -1,4 +1,5 @@
 import datetime
+import importlib.metadata
 import json
 import os.path
 import re
@@ -22,6 +23,11 @@ RESOURCES_HASH = {
 
 with open(local_path("batch_script.sh")) as f:
     BATCH_SCRIPT = f.read()
+
+try:
+    BATCHSPAWNER_VERSION = importlib.metadata.version("batchspawner")
+except importlib.metadata.PackageNotFoundError:
+    BATCHSPAWNER_VERSION = None
 
 
 class MOSlurmSpawner(SlurmSpawner):
@@ -114,6 +120,7 @@ class MOSlurmSpawner(SlurmSpawner):
             hash_option_form_js=RESOURCES_HASH["option_form.js"],
             partitions=partitions,
             default_partition=default_partition,
+            batchspawner_version=BATCHSPAWNER_VERSION,
             jsondata=jsondata,
         )
 

--- a/jupyterhub_moss/templates/option_form.html
+++ b/jupyterhub_moss/templates/option_form.html
@@ -221,24 +221,31 @@ window.SLURM_DATA = JSON.parse('{{ jsondata }}');
           value=""
           disabled
         />
-        <input
-          type="text"
-          id="environment_add_name"
-          placeholder="Environment name"
-        />
-        <input
-          type="text"
-          id="environment_add_path"
-          placeholder="/path/to/jupyter/env/bin *"
-        />
-        <button
-          type="button"
-          id="environment_add_button"
-          title="Add this environment to &#13;the list of custom environments"
-          disabled
-        >
-          &#xff0b;
-        </button>
+        <div>
+          <div class="environment-add-div">
+            <input
+              type="text"
+              id="environment_add_name"
+              placeholder="Environment name"
+            />
+            <input
+              type="text"
+              id="environment_add_path"
+              placeholder="/path/to/jupyter/env/bin *"
+            />
+            <button
+              type="button"
+              id="environment_add_button"
+              title="Add this environment to &#13;the list of custom environments"
+              disabled
+            >
+              &#xff0b;
+            </button>
+          </div>
+          <div class="label-extra-info">
+            &#9888; The <a href="https://pypi.org/project/batchspawner/">batchspawner</a> package{% if batchspawner_version %} (version {{batchspawner_version}}){% endif %} must be installed in this environment.
+          </div>
+        </div>
       </div>
     </div>
     <hr />

--- a/jupyterhub_moss/templates/option_form.html
+++ b/jupyterhub_moss/templates/option_form.html
@@ -242,7 +242,7 @@ window.SLURM_DATA = JSON.parse('{{ jsondata }}');
               &#xff0b;
             </button>
           </div>
-          <div class="label-extra-info">
+          <div>
             &#9888; The <a href="https://pypi.org/project/batchspawner/">batchspawner</a> package{% if batchspawner_version %} (version {{batchspawner_version}}){% endif %} must be installed in this environment.
           </div>
         </div>

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,7 +21,7 @@ classifiers =
 [options]
 packages = find:
 include_package_data = True
-python_requires = >=3.7
+python_requires = >=3.8
 install_requires =
     batchspawner
     jinja2


### PR DESCRIPTION
This PR adds the information about the `batchspawner` package requirement and current version.

By using `importlib.metadata`, Python >= 3.8 is now required.

This gives:

<img width="582" alt="Screen Shot 2022-01-14 at 15 10 02" src="https://user-images.githubusercontent.com/9449698/149528697-853aef82-46e4-47d6-b010-e7f8fe31f223.png">

