### PR TITLE
Advertise jupyterhub version to use in custom env.

### DIFF
--- a/jupyterhub_moss/spawner.py
+++ b/jupyterhub_moss/spawner.py
@@ -28,6 +28,10 @@ try:
     BATCHSPAWNER_VERSION = importlib.metadata.version("batchspawner")
 except importlib.metadata.PackageNotFoundError:
     BATCHSPAWNER_VERSION = None
+try:
+    JUPYTERHUB_VERSION = importlib.metadata.version("jupyterhub")
+except importlib.metadata.PackageNotFoundError:
+    JUPYTERHUB_VERSION = None
 
 
 class MOSlurmSpawner(SlurmSpawner):
@@ -121,6 +125,7 @@ class MOSlurmSpawner(SlurmSpawner):
             partitions=partitions,
             default_partition=default_partition,
             batchspawner_version=BATCHSPAWNER_VERSION,
+            jupyterhub_version=JUPYTERHUB_VERSION,
             jsondata=jsondata,
         )
 

--- a/jupyterhub_moss/templates/option_form.html
+++ b/jupyterhub_moss/templates/option_form.html
@@ -243,7 +243,9 @@ window.SLURM_DATA = JSON.parse('{{ jsondata }}');
             </button>
           </div>
           <div>
-            &#9888; The <a href="https://pypi.org/project/batchspawner/">batchspawner</a> package{% if batchspawner_version %} (version {{batchspawner_version}}){% endif %} must be installed in this environment.
+            &#9888; Required packages in custom environments:<br>
+            <a href="https://pypi.org/project/batchspawner/">batchspawner</a>{% if batchspawner_version %}~={{batchspawner_version}}{% endif %} and
+            <a href="https://pypi.org/project/jupyterhub/">jupyterhub</a>{% if jupyterhub_version %}~={{jupyterhub_version}}{% endif %}.
           </div>
         </div>
       </div>


### PR DESCRIPTION
This PR adds the version of jupyterhub to use in the info about custom env.
Indeed, the hub server using JHub v2 is incompatible with JHub v1 in the spawned servers...