### PR TITLE
Added `add_to_path` option for `jupyter_environments`

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ c.MOSlurmSpawner.partitions = {
             "default": {                   # Jupyter environment internal identifier
                 "path": "/env/path/bin/",  # Path to Python environment bin/ used to start jupyter on the Slurm nodes
                 "description": "Default",  # Text displayed for this environment select option
+                "add_to_path": True,       # Toggle adding the environment to shell PATH (optional, default: True)
             },
         },
     },
@@ -73,6 +74,7 @@ c.MOSlurmSpawner.partitions = {
             "default": {
                 "path": "/path/to/jupyter/env/for/partition_2/bin/",
                 "description": "Default",
+                "add_to_path": True,
             },
         },
     },
@@ -88,6 +90,7 @@ c.MOSlurmSpawner.partitions = {
             "default": {
                 "path": "/path/to/jupyter/env/for/partition_3/bin/",
                 "description": "Partition 3 default",
+                "add_to_path": True,
         },
     },
 }
@@ -125,6 +128,8 @@ c.MOSlurmSpawner.partitions = {
     is used to start Jupyter. This path can be changed according to the
     partitions.
   - `description`: Text used for display in the selection options.
+  - `add_to_path`: Whether or not to prepend the environment `path` to shell
+    `PATH`.
 
 ### Spawn page
 

--- a/demo_jupyterhub_conf.py
+++ b/demo_jupyterhub_conf.py
@@ -40,10 +40,12 @@ c.MOSlurmSpawner.partitions = {
             "default": {
                 "path": "/default/jupyter_env_path/bin/",
                 "description": "Operating system (default)",
+                "add_to_path": False,
             },
             "new-x86": {
                 "path": "/new-x86/jupyter_env_path/bin/",
                 "description": "New environment x86 (latest)",
+                "add_to_path": True,
             },
             "latest": {
                 "path": "/latest/jupyter_env_path/bin/",

--- a/jupyterhub_moss/batch_script.sh
+++ b/jupyterhub_moss/batch_script.sh
@@ -16,5 +16,5 @@
 set -euo pipefail
 
 trap 'echo SIGTERM received' TERM
-
+{{prologue}}
 {{cmd}}

--- a/jupyterhub_moss/spawner.py
+++ b/jupyterhub_moss/spawner.py
@@ -221,12 +221,14 @@ class MOSlurmSpawner(SlurmSpawner):
             # Set path to use from first environment for the current partition
             options["environment_path"] = partition_environments[0]["path"]
 
-        # Add environment_path to PATH unless it is in the settings with add_to_path=False
-        corresponding_env = find(
+        corresponding_default_env = find(
             lambda env: env["path"] == options["environment_path"],
             partition_environments,
         )
-        if corresponding_env is None or corresponding_env.get("add_to_path", True):
+        # custom envs are always added to PATH, defaults ones only if add_to_path is True
+        if corresponding_default_env is None or corresponding_default_env.get(
+            "add_to_path", True
+        ):
             options["prologue"] = f"export PATH={options['environment_path']}:$PATH"
 
         # Virtualenv is not activated, we need to provide full path

--- a/jupyterhub_moss/spawner.py
+++ b/jupyterhub_moss/spawner.py
@@ -55,6 +55,7 @@ class MOSlurmSpawner(SlurmSpawner):
                         per_key_traits={
                             "path": traitlets.Unicode(),
                             "description": traitlets.Unicode(),
+                            "add_to_path": traitlets.Bool(default_value=True),
                         },
                     ),
                 ),
@@ -219,6 +220,13 @@ class MOSlurmSpawner(SlurmSpawner):
                 self.partitions[partition]["jupyter_environments"].values()
             )[0]
             options["environment_path"] = default_venv["path"]
+
+        for env in self.partitions[partition]["jupyter_environments"].values():
+            if env["path"] == options["environment_path"] and not env["add_to_path"]:
+                break  # Do not add environment_path to PATH
+        else:
+            # Add environment_path to PATH
+            options["prologue"] = f"export PATH={options['environment_path']}:$PATH"
 
         # Virtualenv is not activated, we need to provide full path
         self.batchspawner_singleuser_cmd = os.path.join(

--- a/jupyterhub_moss/utils.py
+++ b/jupyterhub_moss/utils.py
@@ -1,7 +1,6 @@
 import hashlib
 import os.path
-from collections.abc import Iterable
-from typing import Any, Callable, Optional
+from typing import Any, Callable, Iterable, Optional
 
 
 def local_path(path: str) -> str:

--- a/jupyterhub_moss/utils.py
+++ b/jupyterhub_moss/utils.py
@@ -1,5 +1,7 @@
 import hashlib
 import os.path
+from collections.abc import Iterable
+from typing import Any, Callable, Optional
 
 
 def local_path(path: str) -> str:
@@ -10,3 +12,10 @@ def local_path(path: str) -> str:
 def file_hash(filename: str) -> str:
     with open(filename, "rb") as f:
         return hashlib.sha256(f.read()).hexdigest()
+
+
+def find(function: Callable[[Any], bool], iterable: Iterable[Any]) -> Optional[Any]:
+    for item in iterable:
+        if function(item):
+            return item
+    return None


### PR DESCRIPTION
This option allows to toggle whether or not the jupyter environment path is prepended to `PATH`.
For instance, when giving access to Python installed on the system, the virtual environment used for jupyter server should not be added to the `PATH`.
Custom environments are always added to `PATH`.