### PR TITLE
Updated add/remove buttons style

### DIFF
--- a/jupyterhub_moss/form/option_form.css
+++ b/jupyterhub_moss/form/option_form.css
@@ -130,7 +130,8 @@
 }
 
 .environment-remove-button {
-  padding: 0;
+  padding-left: 0;
+  padding-right: 0;
   height: 1.8rem;
   line-height: 0.9rem;
   align-self: baseline;
@@ -151,7 +152,8 @@
 }
 
 #environment_add_button {
-  padding: 0;
+  padding-left: 0;
+  padding-right: 0;
 }
 
 #environment_add_button:disabled {

--- a/jupyterhub_moss/form/option_form.css
+++ b/jupyterhub_moss/form/option_form.css
@@ -130,6 +130,7 @@
 }
 
 .environment-remove-button {
+  padding: 0;
   height: 1.8rem;
   line-height: 0.9rem;
   align-self: baseline;
@@ -147,6 +148,10 @@
 
 #environment_add_path {
   flex: 1;
+}
+
+#environment_add_button {
+  padding: 0;
 }
 
 #environment_add_button:disabled {


### PR DESCRIPTION
This PR fixes the layout and to some extent the button size issue with older firefox version:

<img width="441" alt="Screen Shot 2022-01-28 at 12 08 38" src="https://user-images.githubusercontent.com/9449698/151536948-31f0518e-3fa4-4bc9-a679-9d4988700f5e.png">
The side effect on up-to-date firefox is smaller buttons:

<img width="441" alt="Screen Shot 2022-01-28 at 12 08 38" src="https://user-images.githubusercontent.com/9449698/151536802-d418265a-789a-433d-8c55-8374748a9d29.png">


closes #47