### PR TITLE
Add memory option in advanced tab

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,14 +177,21 @@ The following query argument is required:
 The following optional query arguments are available:
 
 - `environment_path`: Path to Python environment bin/ used to start Jupyter
-- `exclusive`: Set to `true` for exclusive node usage (`--exclusive`)
+- `exclusive`: Set to `true` for exclusive node usage
+  ([`--exclusive`](https://slurm.schedmd.com/sbatch.html#OPT_exclusive))
 - `jupyterlab`: Set to `true` to start with JupyterLab
-- `ngpus`: Number of GPUs (`--gres:<gpu>:`)
-- `nprocs`: Number of CPUs per task (`--cpus-per-task`)
+- `mem`: Total amount of memory per node
+  ([`--mem`](https://slurm.schedmd.com/sbatch.html#OPT_mem))
+- `ngpus`: Number of GPUs
+  ([`--gres:<gpu>:`](https://slurm.schedmd.com/sbatch.html#OPT_gres))
+- `nprocs`: Number of CPUs per task
+  ([`--cpus-per-task`](https://slurm.schedmd.com/sbatch.html#OPT_cpus-per-task))
 - `options`: Extra SLURM options
 - `output`: Set to `true` to save logs to `slurm-*.out` files.
-- `reservation`: SLURM reservation name (`--reservation`)
-- `runtime`: Job duration as hh:mm:ss (`--time`)
+- `reservation`: SLURM reservation name
+  ([`--reservation`](https://slurm.schedmd.com/sbatch.html#OPT_reservation))
+- `runtime`: Job duration as hh:mm:ss
+  ([`--time`](https://slurm.schedmd.com/sbatch.html#OPT_time))
 
 ## Development
 

--- a/demo_jupyterhub_conf.py
+++ b/demo_jupyterhub_conf.py
@@ -19,8 +19,12 @@ jupyterhub_moss.set_config(c)
 class MOckSlurmSpawner(jupyterhub_moss.MOSlurmSpawner):
     def _get_slurm_info(self):
         return {
-            k: {"nodes": v["max_nprocs"], "idle": random.randint(0, v["max_nprocs"])}
-            for k, v in self.partitions.items()
+            k: {
+                "nodes": v["max_nprocs"],
+                "idle": random.randint(0, v["max_nprocs"]),
+                "max_mem": 128000 * (index + 1),
+            }
+            for index, (k, v) in enumerate(self.partitions.items())
         }
 
 

--- a/jupyterhub_moss/batch_script.sh
+++ b/jupyterhub_moss/batch_script.sh
@@ -7,6 +7,7 @@
 {% if runtime    %}#SBATCH --time={{runtime}}
 {% endif %}{% if gres       %}#SBATCH --gres={{gres}}
 {% endif %}{% if nprocs     %}#SBATCH --cpus-per-task={{nprocs}}
+{% endif %}{% if mem        %}#SBATCH --mem={{mem}}
 {% endif %}{% if reservation%}#SBATCH --reservation={{reservation}}
 {% endif %}{% if exclusive  %}#SBATCH --exclusive
 {% endif %}{% if not output %}#SBATCH --output=/dev/null

--- a/jupyterhub_moss/form/option_form.css
+++ b/jupyterhub_moss/form/option_form.css
@@ -94,12 +94,18 @@
   text-align: left;
 }
 
+.form-field-div {
+  display: flex;
+  flex: 0 1 0;
+}
+
 @media (max-width: 768px) {
   .form-container label {
     grid-column: 1;
   }
   .form-container input,
-  .form-container select {
+  .form-container select,
+  .form-field-div {
     grid-column: 1 / 3;
   }
   .form-container input[type='checkbox'] {

--- a/jupyterhub_moss/form/option_form.js
+++ b/jupyterhub_moss/form/option_form.js
@@ -314,8 +314,19 @@ function setSimplePartition(name) {
   }
 }
 
+function updateMemValue() {
+  const memHiddenElem = document.getElementById('mem');
+  const memInputElem = document.getElementById('mem_input');
+  const value = memInputElem.value;
+
+  // Pass empty field and 0 as is, append G for others
+  memHiddenElem.value = value && value !== '0' ? `${value}G` : value;
+}
+
 function updatePartitionLimits() {
   const nprocsElem = document.getElementById('nprocs');
+  const memSpanElem = document.getElementById('max_memory_span');
+  const memInputElem = document.getElementById('mem_input');
   const ngpusElem = document.getElementById('ngpus');
 
   const partition = document.getElementById('partition').value;
@@ -323,6 +334,14 @@ function updatePartitionLimits() {
 
   if (nprocsElem.value > info.max_nprocs) nprocsElem.value = info.max_nprocs;
   nprocsElem.max = info.max_nprocs;
+
+  const max_mem = Math.floor(info.max_mem / 1024);
+  if (memInputElem.value && memInputElem.value > max_mem) {
+    memInputElem.value = max_mem;
+  }
+  memInputElem.max = max_mem;
+  memSpanElem.textContent = `${max_mem} GB`;
+  updateMemValue();
 
   if (ngpusElem.value > info.max_ngpus) ngpusElem.value = info.max_ngpus;
   ngpusElem.max = info.max_ngpus;
@@ -343,6 +362,7 @@ function storeConfigToLocalStorage() {
   const fieldNames = [
     'partition',
     'nprocs',
+    'mem_input',
     'ngpus',
     'runtime',
     'jupyterlab',
@@ -504,6 +524,11 @@ document.addEventListener('DOMContentLoaded', () => {
   document
     .getElementById('environment_simple')
     .addEventListener('change', (e) => selectEnvironment(e.target.value));
+
+  // Update mem when mem_input changes
+  document
+    .getElementById('mem_input')
+    .addEventListener('change', (e) => updateMemValue());
 
   // Handle add custom environment
   document

--- a/jupyterhub_moss/form/option_form.js
+++ b/jupyterhub_moss/form/option_form.js
@@ -325,15 +325,18 @@ function updateMemValue() {
 
 function updatePartitionLimits() {
   const nprocsElem = document.getElementById('nprocs');
+  const nprocsSpanElem = document.getElementById('max_nprocs_span');
   const memSpanElem = document.getElementById('max_memory_span');
   const memInputElem = document.getElementById('mem_input');
   const ngpusElem = document.getElementById('ngpus');
+  const ngpusSpanElem = document.getElementById('max_ngpus_span');
 
   const partition = document.getElementById('partition').value;
   const info = window.SLURM_DATA.partitions[partition];
 
   if (nprocsElem.value > info.max_nprocs) nprocsElem.value = info.max_nprocs;
   nprocsElem.max = info.max_nprocs;
+  nprocsSpanElem.textContent = info.max_nprocs;
 
   const max_mem = Math.floor(info.max_mem / 1024);
   if (memInputElem.value && memInputElem.value > max_mem) {
@@ -346,6 +349,7 @@ function updatePartitionLimits() {
   if (ngpusElem.value > info.max_ngpus) ngpusElem.value = info.max_ngpus;
   ngpusElem.max = info.max_ngpus;
   ngpusElem.disabled = info.max_ngpus === 0;
+  ngpusSpanElem.textContent = info.max_ngpus;
 
   document.querySelectorAll('input[name="ngpus_simple"]').forEach((element) => {
     const isVisible = element.value <= info.max_ngpus;

--- a/jupyterhub_moss/spawner.py
+++ b/jupyterhub_moss/spawner.py
@@ -103,7 +103,7 @@ class MOSlurmSpawner(SlurmSpawner):
             info["nodes"] += 1
             if state == "idle":
                 info["idle"] += 1
-            info["max_mem"] = max(info["max_mem"], memory)
+            info["max_mem"] = max(info["max_mem"], int(memory))
         return slurm_info
 
     @staticmethod

--- a/jupyterhub_moss/spawner.py
+++ b/jupyterhub_moss/spawner.py
@@ -93,16 +93,17 @@ class MOSlurmSpawner(SlurmSpawner):
     def _get_slurm_info(self):
         """Returns information about partitions from slurm"""
         # Get number of nodes and idle nodes for all partitions
-        state = check_output(["sinfo", "-a", "-N", "--noheader", "-o", "%R %t"]).decode(
-            "utf-8"
-        )
-        slurm_info = defaultdict(lambda: {"nodes": 0, "idle": 0})
+        state = check_output(
+            ["sinfo", "-a", "-N", "--noheader", "-o", "%R %t %m"]
+        ).decode("utf-8")
+        slurm_info = defaultdict(lambda: {"nodes": 0, "idle": 0, "max_mem": 0})
         for line in state.splitlines():
-            partition, state = line.split()
+            partition, state, memory = line.split()
             info = slurm_info[partition]
             info["nodes"] += 1
             if state == "idle":
                 info["idle"] += 1
+            info["max_mem"] = max(info["max_mem"], memory)
         return slurm_info
 
     @staticmethod
@@ -117,6 +118,7 @@ class MOSlurmSpawner(SlurmSpawner):
             partitions[name] = {
                 "max_nnodes": slurm_info[name]["nodes"],
                 "nnodes_idle": slurm_info[name]["idle"],
+                "max_mem": slurm_info[name]["max_mem"],
                 **info,
             }
             if info["simple"] and default_partition is None:
@@ -145,6 +147,7 @@ class MOSlurmSpawner(SlurmSpawner):
         "partition": str,
         "runtime": str,
         "nprocs": int,
+        "mem": str,
         "reservation": str,
         "exclusive": lambda v: v == "true",
         "ngpus": int,
@@ -157,6 +160,8 @@ class MOSlurmSpawner(SlurmSpawner):
     _RUNTIME_REGEXP = re.compile(
         "^(?P<hours>[0-9]+)(?::(?P<minutes>[0-5]?[0-9]))?(?::(?P<seconds>[0-5]?[0-9]))?$"
     )
+
+    _MEM_REGEXP = re.compile("^[0-9]*([0-9]+[KMGT])?$")
 
     def __validate_options(self, options):
         """Check validity of options"""
@@ -179,6 +184,9 @@ class MOSlurmSpawner(SlurmSpawner):
             and not 1 <= options["nprocs"] <= partition_info["max_nprocs"]
         ):
             raise AssertionError("Error in number of CPUs")
+
+        if "mem" in options and self._MEM_REGEXP.match(options["mem"]) is None:
+            raise AssertionError("Error in memory syntax")
 
         if "reservation" in options and "\n" in options["reservation"]:
             raise AssertionError("Error in reservation")

--- a/jupyterhub_moss/templates/option_form.html
+++ b/jupyterhub_moss/templates/option_form.html
@@ -179,6 +179,20 @@ window.SLURM_DATA = JSON.parse('{{ jsondata }}');
       min="1"
       value="1"
     />
+    <label for="mem">
+      Memory <span class="label-extra-info">per node (--mem, max: <span id="max_memory_span"></span>)</span>:
+    </label>
+    <div class="form-field-div" title="Memory in GigaBytes">
+      <input type="hidden" id="mem" name="mem" value=""/>
+      <input
+        type="number"
+        id="mem_input"
+        min="0"
+        value=""
+        placeholder="Default"
+      />
+      <span class="label-extra-info">&nbsp;GB</span>
+    </div>
     <label for="ngpus">
       Number of GPUs <span class="label-extra-info">(--gres:&lt;gpu&gt;:)</span>:
     </label>

--- a/jupyterhub_moss/templates/option_form.html
+++ b/jupyterhub_moss/templates/option_form.html
@@ -170,7 +170,7 @@ window.SLURM_DATA = JSON.parse('{{ jsondata }}');
       {% endfor %}
     </select>
     <label for="nprocs" accesskey="c">
-      Number of CPUs <span class="label-extra-info">per task (--cpus-per-task)</span>:
+      Number of CPUs <span class="label-extra-info">per task (--cpus-per-task, max: <span id="max_nprocs_span"></span>)</span>:
     </label>
     <input
       type="number"
@@ -194,7 +194,7 @@ window.SLURM_DATA = JSON.parse('{{ jsondata }}');
       <span class="label-extra-info">&nbsp;GB</span>
     </div>
     <label for="ngpus">
-      Number of GPUs <span class="label-extra-info">(--gres:&lt;gpu&gt;:)</span>:
+      Number of GPUs <span class="label-extra-info">(--gres:&lt;gpu&gt;:, max: <span id="max_ngpus_span"></span>)</span>:
     </label>
     <input
       type="number"


### PR DESCRIPTION
This PR adds a way to set the total memory to ask in the advanced panel.

slurm works by default with megabytes (one can use gigabyes by using `G`) and I kept it this way in the backend, so it is possible to pass a `mem` query param exactly as `--mem` SLURM param.

The front-end works in gigabytes to spare the user typing 3 more digits and deals with the conversion.

I didn't add a memory option in the simple tab... to keep it simple and see how it goes.

closes #51