### PR TITLE
Update the display of max CPU/Mem/GPU in the advanced panel

### DIFF
--- a/jupyterhub_moss/form/option_form.js
+++ b/jupyterhub_moss/form/option_form.js
@@ -326,7 +326,7 @@ function updateMemValue() {
 function updatePartitionLimits() {
   const nprocsElem = document.getElementById('nprocs');
   const nprocsSpanElem = document.getElementById('max_nprocs_span');
-  const memSpanElem = document.getElementById('max_memory_span');
+  const memSpanElem = document.getElementById('max_mem_span');
   const memInputElem = document.getElementById('mem_input');
   const ngpusElem = document.getElementById('ngpus');
   const ngpusSpanElem = document.getElementById('max_ngpus_span');
@@ -343,7 +343,7 @@ function updatePartitionLimits() {
     memInputElem.value = max_mem;
   }
   memInputElem.max = max_mem;
-  memSpanElem.textContent = `${max_mem} GB`;
+  memSpanElem.textContent = `${max_mem}GB`;
   updateMemValue();
 
   if (ngpusElem.value > info.max_ngpus) ngpusElem.value = info.max_ngpus;

--- a/jupyterhub_moss/templates/option_form.html
+++ b/jupyterhub_moss/templates/option_form.html
@@ -170,17 +170,20 @@ window.SLURM_DATA = JSON.parse('{{ jsondata }}');
       {% endfor %}
     </select>
     <label for="nprocs" accesskey="c">
-      Number of CPUs <span class="label-extra-info">per task (--cpus-per-task, max: <span id="max_nprocs_span"></span>)</span>:
+      Number of CPUs <span class="label-extra-info">(--cpus-per-task)</span>:
     </label>
-    <input
-      type="number"
-      id="nprocs"
-      name="nprocs"
-      min="1"
-      value="1"
-    />
+    <div class="form-field-div">
+      <input
+        type="number"
+        id="nprocs"
+        name="nprocs"
+        min="1"
+        value="1"
+      />
+      <span class="label-extra-info">&nbsp;/&nbsp;<span id="max_nprocs_span">-</span></span>
+    </div>
     <label for="mem">
-      Memory <span class="label-extra-info">per node (--mem, max: <span id="max_memory_span"></span>)</span>:
+      Total memory <span class="label-extra-info">(--mem)</span>:
     </label>
     <div class="form-field-div" title="Memory in GigaBytes">
       <input type="hidden" id="mem" name="mem" value=""/>
@@ -191,18 +194,21 @@ window.SLURM_DATA = JSON.parse('{{ jsondata }}');
         value=""
         placeholder="Default"
       />
-      <span class="label-extra-info">&nbsp;GB</span>
+      <span class="label-extra-info">&nbsp;/&nbsp;<span id="max_mem_span">-</span></span>
     </div>
     <label for="ngpus">
-      Number of GPUs <span class="label-extra-info">(--gres:&lt;gpu&gt;:, max: <span id="max_ngpus_span"></span>)</span>:
+      Number of GPUs <span class="label-extra-info">(--gres:&lt;gpu&gt;:)</span>:
     </label>
-    <input
-      type="number"
-      id="ngpus"
-      name="ngpus"
-      min="0"
-      value="0"
-    />
+    <div class="form-field-div">
+      <input
+        type="number"
+        id="ngpus"
+        name="ngpus"
+        min="0"
+        value="0"
+      />
+      <span class="label-extra-info">&nbsp;/&nbsp;<span id="max_ngpus_span">-</span></span>
+    </div>
     <label for="runtime" accesskey="r">
       Job duration <span class="label-extra-info">(as hh:mm:ss, --time)</span>:
     </label>


### PR DESCRIPTION
This PR changes the way to display the max number of CPU, mem and GPU.
By placing it after the input rather than in the label, it reduces the length of the label and makes the max info more visible.

![Screenshot from 2022-04-29 09-46-05](https://user-images.githubusercontent.com/9449698/165904077-76e913a0-4e39-4209-905a-9161dcb636ce.png)
