### PR TITLE
Add "preview" support of Singularity images

### DIFF
--- a/jupyterhub_moss/spawner.py
+++ b/jupyterhub_moss/spawner.py
@@ -79,6 +79,12 @@ class MOSlurmSpawner(SlurmSpawner):
                 env.setdefault("add_to_path", True)
         return partitions
 
+    singularity_cmd = traitlets.List(
+        trait=traitlets.Unicode(),
+        default_value=["singularity", "exec"],
+        help="Singularity command to use for starting jupyter server in container",
+    ).tag(config=True)
+
     FORM_TEMPLATE = Environment(
         loader=FileSystemLoader(TEMPLATE_PATH),
         autoescape=False,
@@ -238,6 +244,17 @@ class MOSlurmSpawner(SlurmSpawner):
         if "environment_path" not in options:
             # Set path to use from first environment for the current partition
             options["environment_path"] = partition_environments[0]["path"]
+
+        if options["environment_path"].endswith(".sif"):
+            # Use singularity image
+            self.batchspawner_singleuser_cmd = " ".join(
+                [
+                    *self.singularity_cmd,
+                    options["environment_path"],
+                    "batchspawner-singleuser",
+                ]
+            )
+            return options
 
         corresponding_default_env = find(
             lambda env: env["path"] == options["environment_path"],


### PR DESCRIPTION
This PR adds a support of singularity images.
The command to start singularity can be tuned in the config.

The requirements on the singularity image is that batchspawner and jupyterhub (and obviously jupyter/jupyterlab) are available in the container and are in the PATH.

There is a convenient flow in the current implementation: one can pass options (e.g., `--nv` to enable nvidia GPU support and `--bind` to "mount" directories in the container, like `/data`) as space separated along with the "environment path".
In a final version, I would avoid that, either with the right options in the "singularity_cmd" or through specific inputs in the UI, but for a "preview" feature it's good to have flexibility.

I didn't advertise the support of it in the interface on purpose to keep it as a beta feature for now.