### PR TITLE
Removed the `exclusive` option checkbox

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,8 +177,6 @@ The following query argument is required:
 The following optional query arguments are available:
 
 - `environment_path`: Path to Python environment bin/ used to start Jupyter
-- `exclusive`: Set to `true` for exclusive node usage
-  ([`--exclusive`](https://slurm.schedmd.com/sbatch.html#OPT_exclusive))
 - `jupyterlab`: Set to `true` to start with JupyterLab
 - `mem`: Total amount of memory per node
   ([`--mem`](https://slurm.schedmd.com/sbatch.html#OPT_mem))

--- a/jupyterhub_moss/form/option_form.js
+++ b/jupyterhub_moss/form/option_form.js
@@ -1,4 +1,4 @@
-const CONFIG_NAME = 'form-config:v2';
+const CONFIG_NAME = 'form-config:v3';
 const CUSTOM_ENV_CONFIG_NAME = 'custom-environment-config:v1';
 
 function removeAllChildren(node) {
@@ -370,7 +370,6 @@ function storeConfigToLocalStorage() {
     'ngpus',
     'runtime',
     'jupyterlab',
-    'exclusive',
     'output',
     'reservation',
     'options',
@@ -458,7 +457,6 @@ document.addEventListener('DOMContentLoaded', () => {
   resetSpawnForm(); // Init
 
   const nprocsElem = document.getElementById('nprocs');
-  const exclusiveElem = document.getElementById('exclusive');
   const ngpusElem = document.getElementById('ngpus');
   const jupyterlabElem = document.getElementById('jupyterlab');
   const runtimeElem = document.getElementById('runtime');
@@ -484,7 +482,6 @@ document.addEventListener('DOMContentLoaded', () => {
     .forEach((element) => {
       element.addEventListener('change', (e) => {
         nprocsElem.value = e.target.value;
-        exclusiveElem.checked = e.target.id === 'maximumCore';
       });
     });
   // GPUs

--- a/jupyterhub_moss/spawner.py
+++ b/jupyterhub_moss/spawner.py
@@ -149,7 +149,6 @@ class MOSlurmSpawner(SlurmSpawner):
         "nprocs": int,
         "mem": str,
         "reservation": str,
-        "exclusive": lambda v: v == "true",
         "ngpus": int,
         "jupyterlab": lambda v: v == "true",
         "options": lambda v: v.strip(),
@@ -221,6 +220,14 @@ class MOSlurmSpawner(SlurmSpawner):
         self.__validate_options(options)
 
         partition = options["partition"]
+
+        # Specific handling of exclusive flag
+        # When mem=0 or all CPU are requested, set the exclusive flag
+        if (
+            options["nprocs"] == self.partitions[partition]["max_nprocs"]
+            or options.get("mem", None) == "0"
+        ):
+            options["exclusive"] = True
 
         # Specific handling of jupyterlab
         self.default_url = "/lab" if options.get("jupyterlab", False) else ""

--- a/jupyterhub_moss/templates/option_form.html
+++ b/jupyterhub_moss/templates/option_form.html
@@ -273,13 +273,6 @@ window.SLURM_DATA = JSON.parse('{{ jsondata }}');
       </div>
     </div>
     <hr />
-    <label for="exclusive">Exclusive <span class="label-extra-info">(--exclusive)</span>:</label>
-    <input
-      type="checkbox"
-      id="exclusive"
-      name="exclusive"
-      value="true"
-    />
     <label for="output">Save session logs <span class="label-extra-info">to slurm-*.out</span>:</label>
     <input
       type="checkbox"


### PR DESCRIPTION
This MR removes the `Exclusive` checkbox from the advanced tab.
This checkbox can be error prone since it is persisted and one might change the requested resources to fewer CPUs without checking the state of the exclusive checkbox.

Instead, the backend automatically add it when all cores are requested or requested mem is 0 (i.e., request all the memory).
A user  can still pass `--exclusive` in the `Extra options` to explicitly set it.

closes #56