### PR TITLE
Changed custom environment radio button behavior

### DIFF
--- a/jupyterhub_moss/form/option_form.js
+++ b/jupyterhub_moss/form/option_form.js
@@ -26,6 +26,8 @@ function createEnvironmentDiv(key, description, path, checked = false) {
   input.setAttribute('title', title);
   input.setAttribute('name', 'environment_path');
   input.setAttribute('value', path);
+
+  input.addEventListener('change', updateEnvironmentAddPathRequired);
   if (checked) {
     input.setAttribute('checked', '');
   }
@@ -253,6 +255,16 @@ function setVisible(element, visible) {
     element.removeAttribute('hidden');
   } else {
     element.setAttribute('hidden', '');
+  }
+}
+
+function updateEnvironmentAddPathRequired() {
+  const environmentAddRadio = document.getElementById('environment_add_radio');
+  const environmentAddPath = document.getElementById('environment_add_path');
+  if (environmentAddRadio.checked) {
+    environmentAddPath.setAttribute('required', '');
+  } else {
+    environmentAddPath.removeAttribute('required');
   }
 }
 
@@ -536,22 +548,18 @@ document.addEventListener('DOMContentLoaded', () => {
     .getElementById('environment_add_path')
     .addEventListener('input', (e) => {
       const isInputEmpty = e.target.value === '';
-      if (
-        !environmentAddRadio.disabled &&
-        isInputEmpty &&
-        environmentAddRadio.checked
-      ) {
-        // Path just cleared while its radio button was selected
-        resetEnvironmentSelection();
-      }
-      if (environmentAddRadio.disabled && !isInputEmpty) {
+      if (environmentAddRadio.value === '' && !isInputEmpty) {
         // First input in the path: select its radio button
         environmentAddRadio.checked = true;
       }
       environmentAddRadio.value = e.target.value;
-      environmentAddRadio.disabled = isInputEmpty;
       environmentAddButton.disabled = isInputEmpty;
     });
+
+  environmentAddRadio.addEventListener(
+    'change',
+    updateEnvironmentAddPathRequired
+  );
 
   environmentAddButton.addEventListener('click', (e) => {
     const key = `custom-${Date.now()}`; // Poor man's UUID
@@ -562,6 +570,7 @@ document.addEventListener('DOMContentLoaded', () => {
     );
     if (environmentAddRadio.checked) {
       selectEnvironment(key);
+      updateEnvironmentAddPathRequired();
     }
     environmentAddName.value = '';
     environmentAddPath.value = '';

--- a/jupyterhub_moss/templates/option_form.html
+++ b/jupyterhub_moss/templates/option_form.html
@@ -241,7 +241,6 @@ window.SLURM_DATA = JSON.parse('{{ jsondata }}');
           id="environment_add_radio"
           name="environment_path"
           value=""
-          disabled
         />
         <div>
           <div class="environment-add-div">


### PR DESCRIPTION
This PR changes the behavior of the new custom env radio button so that it is always enabled.
To avoid user spawning a custom env without specifying a path, when the radio button of the new env is checked, the input text field for the path is `required` (thanks @axelboc for the trick).

attn @mretegan 