### PR TITLE
Changed available options for number of CPU in simple tab

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
   partitions set in the Spawner and allows the user to select Slurm resources to
   use.
 
-<img style="margin:auto" src=https://user-images.githubusercontent.com/9449698/133999344-0a940981-fd97-41d3-a717-c01f103776f7.png width="50%">
+<img style="margin:auto" src=https://user-images.githubusercontent.com/9449698/194308511-f0e6d6a9-ba7a-4086-a871-23b08523c61a.png width="50%">
 
 ## Install
 
@@ -137,7 +137,7 @@ The spawn page (available at `/hub/spawn`) will be generated according to the
 partition settings. For example, this is the spawn page generated for the
 partition settings above:
 
-<img style="margin:1rem auto" src=https://user-images.githubusercontent.com/9449698/133999344-0a940981-fd97-41d3-a717-c01f103776f7.png width="50%">
+<img style="margin:1rem auto" src=https://user-images.githubusercontent.com/9449698/194308454-697c717f-daf0-4927-9fa6-6b96ba09dba6.png width="50%">
 
 This spawn page is separated in two tabs: a _Simple_ and an _Advanced_ tab. On
 the _Simple_ tab, the user can choose between the partitions set though
@@ -148,7 +148,8 @@ Clicking on the **Start** button will request the job.
 
 The spawn page adapts to the chosen partition. This is the page when selecting
 the `partition_2`:
-<img style="margin:1rem auto" src=https://user-images.githubusercontent.com/9449698/133999397-68dc7487-a449-4dbf-a82e-b5ca9b3a5010.png width="50%">
+
+<img style="margin:1rem auto" src=https://user-images.githubusercontent.com/9449698/194308524-38417bb8-f520-4940-9c94-af960f11e535.png width="50%">
 
 As the maximum number of cores is different, the CPUs row change accordingly.
 Also, as `gpu` was set for `partition_2`, a new button row appears to enable GPU

--- a/jupyterhub_moss/form/option_form.css
+++ b/jupyterhub_moss/form/option_form.css
@@ -27,13 +27,13 @@
   width: 0;
 }
 
-.radio-toolbar input[type='radio']:focus + label {
-  border: 2px dashed #444;
-}
-
 .radio-toolbar input[type='radio']:checked + label {
   background-color: #d3d3d3;
   border-color: #d3d3d3;
+}
+
+.radio-toolbar input[type='radio']:focus + label {
+  border: 1px dashed #444;
 }
 
 .radio-toolbar input[type='radio']:disabled + label {

--- a/jupyterhub_moss/form/option_form.js
+++ b/jupyterhub_moss/form/option_form.js
@@ -273,12 +273,9 @@ function setSimplePartition(name) {
   const gpuDivSimple = document.getElementById('gpu_simple');
   const gpuRadio0Simple = document.getElementById('0Gpu');
   const ngpusElem = document.getElementById('ngpus');
+  const fourCoreSimple = document.getElementById('fourCores');
   const quarterCpuFieldSimple = document.getElementById('quarterCpufield');
   const quarterCoreSimple = document.getElementById('quarterCore');
-  const halfCpuFieldSimple = document.getElementById('halfCpufield');
-  const halfCoreSimple = document.getElementById('halfCore');
-  const maximumCpuFieldSimple = document.getElementById('maximumCpufield');
-  const maximumCoreSimple = document.getElementById('maximumCore');
   const nprocsElem = document.getElementById('nprocs');
   const runtimeSelect = document.getElementById('runtime_simple');
 
@@ -297,16 +294,19 @@ function setSimplePartition(name) {
 
   // Update displayed NProcs info and values
   // Get number of CPUs for given paritition choice
-  const maxNProcs = info.max_nprocs;
-  const quarterNProcs = Math.floor(maxNProcs / 4);
-  const halfNProcs = Math.floor(maxNProcs / 2);
+  const quarterNProcs = Math.floor(info.max_nprocs / 4);
 
   quarterCpuFieldSimple.textContent = `${quarterNProcs} cores`;
   quarterCoreSimple.value = quarterNProcs;
-  halfCpuFieldSimple.textContent = `${halfNProcs} cores`;
-  halfCoreSimple.value = halfNProcs;
-  maximumCpuFieldSimple.textContent = `${maxNProcs} cores`;
-  maximumCoreSimple.value = maxNProcs;
+  const quarterCoreIsVisible = quarterNProcs > 4;
+  setVisible(
+    document.querySelector(`label[for="${quarterCoreSimple.id}"]`),
+    quarterCoreIsVisible
+  );
+  if (quarterCoreSimple.checked && !quarterCoreIsVisible) {
+    fourCoreSimple.checked = true;
+    fourCoreSimple.dispatchEvent(new Event('change'));
+  }
 
   // Update nprocs according to current CPUs choice
   const selector = document.querySelector(
@@ -503,10 +503,11 @@ document.addEventListener('DOMContentLoaded', () => {
     });
   });
   // JupyterLab using default_url field
-  document.getElementById('jupyterlab_simple').addEventListener(
-    'change', e => {
+  document
+    .getElementById('jupyterlab_simple')
+    .addEventListener('change', (e) => {
       default_url.checked = e.target.checked;
-  });
+    });
   // Runtime
   document.getElementById('runtime_simple').addEventListener('change', (e) => {
     runtimeElem.value = `${e.target.value}:00:00`;

--- a/jupyterhub_moss/form/option_form.js
+++ b/jupyterhub_moss/form/option_form.js
@@ -274,8 +274,10 @@ function setSimplePartition(name) {
   const gpuRadio0Simple = document.getElementById('0Gpu');
   const ngpusElem = document.getElementById('ngpus');
   const fourCoreSimple = document.getElementById('fourCores');
-  const quarterCpuFieldSimple = document.getElementById('quarterCpufield');
   const quarterCoreSimple = document.getElementById('quarterCore');
+  const quarterCoresLabel = document.querySelector(
+    `label[for="${quarterCoreSimple.id}"]`
+  );
   const nprocsElem = document.getElementById('nprocs');
   const runtimeSelect = document.getElementById('runtime_simple');
 
@@ -296,13 +298,10 @@ function setSimplePartition(name) {
   // Get number of CPUs for given paritition choice
   const quarterNProcs = Math.floor(info.max_nprocs / 4);
 
-  quarterCpuFieldSimple.textContent = `${quarterNProcs} cores`;
+  quarterCoresLabel.textContent = `${quarterNProcs} cores`;
   quarterCoreSimple.value = quarterNProcs;
   const quarterCoreIsVisible = quarterNProcs > 4;
-  setVisible(
-    document.querySelector(`label[for="${quarterCoreSimple.id}"]`),
-    quarterCoreIsVisible
-  );
+  setVisible(quarterCoresLabel, quarterCoreIsVisible);
   if (quarterCoreSimple.checked && !quarterCoreIsVisible) {
     fourCoreSimple.checked = true;
     fourCoreSimple.dispatchEvent(new Event('change'));

--- a/jupyterhub_moss/templates/option_form.html
+++ b/jupyterhub_moss/templates/option_form.html
@@ -46,10 +46,7 @@ window.SLURM_DATA = JSON.parse('{{ jsondata }}');
         value="1"
         checked
       />
-      <label for="minimumCore">
-        <p>Minimum</p>
-        <p class="label-extra-info">1 core</p>
-      </label>
+      <label for="minimumCore">1 core</label>
 
       <input
         type="radio"
@@ -57,10 +54,7 @@ window.SLURM_DATA = JSON.parse('{{ jsondata }}');
         name="nprocs_simple"
         value="2"
       />
-      <label for="twoCores">
-        <p>Small</p>
-        <p class="label-extra-info">2 cores</p>
-      </label>
+      <label for="twoCores">2 cores</label>
 
       <input
         type="radio"
@@ -68,20 +62,14 @@ window.SLURM_DATA = JSON.parse('{{ jsondata }}');
         name="nprocs_simple"
         value="4"
       />
-      <label for="fourCores">
-        <p>Medium</p>
-        <p class="label-extra-info">4 cores</p>
-      </label>
+      <label for="fourCores">4 cores</label>
 
       <input
         type="radio"
         id="quarterCore"
         name="nprocs_simple"
       />
-      <label for="quarterCore">
-        <p>Quarter&nbsp;node</p>
-        <p id="quarterCpufield" class="label-extra-info"></p>
-      </label>
+      <label for="quarterCore"></label>
     </div>
 
     <div id="gpu_simple" hidden>

--- a/jupyterhub_moss/templates/option_form.html
+++ b/jupyterhub_moss/templates/option_form.html
@@ -53,32 +53,34 @@ window.SLURM_DATA = JSON.parse('{{ jsondata }}');
 
       <input
         type="radio"
+        id="twoCores"
+        name="nprocs_simple"
+        value="2"
+      />
+      <label for="twoCores">
+        <p>Small</p>
+        <p class="label-extra-info">2 cores</p>
+      </label>
+
+      <input
+        type="radio"
+        id="fourCores"
+        name="nprocs_simple"
+        value="4"
+      />
+      <label for="fourCores">
+        <p>Medium</p>
+        <p class="label-extra-info">4 cores</p>
+      </label>
+
+      <input
+        type="radio"
         id="quarterCore"
         name="nprocs_simple"
       />
       <label for="quarterCore">
         <p>Quarter&nbsp;node</p>
         <p id="quarterCpufield" class="label-extra-info"></p>
-      </label>
-
-      <input
-        type="radio"
-        id="halfCore"
-        name="nprocs_simple"
-      />
-      <label for="halfCore">
-        <p>Half&nbsp;node</p>
-        <p id="halfCpufield" class="label-extra-info"></p>
-      </label>
-
-      <input
-        type="radio"
-        id="maximumCore"
-        name="nprocs_simple"
-      />
-      <label for="maximumCore">
-        <p>Entire&nbsp;node</p>
-        <p id="maximumCpufield" class="label-extra-info"></p>
       </label>
     </div>
 


### PR DESCRIPTION
This PR replaces the CPUs options in the simple tab: 1core, 1/4node, 1/2 node, entire node
with smaller ones: 1, 2, 4 cores and 1/4 node (if > 4cores) in order to promote using lower resources.

The machines are expected to have at least 4 cores....

It is still possible to use as many cores as required from the advanced tab.

closes #61