### PR TITLE
Execute sinfo with batchspawner.run_command

### DIFF
--- a/jupyterhub_moss/spawner.py
+++ b/jupyterhub_moss/spawner.py
@@ -309,6 +309,6 @@ class MOSlurmSpawner(SlurmSpawner):
         self.log.info(f"Used default URL: {self.default_url}")
 
         # refresh environment to be kept in the job
-        self.req_keepvars = self._req_keepvars_default()
+        self.req_keepvars = self.trait_defaults("req_keepvars")
 
         return await super().submit_batch_script()

--- a/jupyterhub_moss/spawner.py
+++ b/jupyterhub_moss/spawner.py
@@ -307,4 +307,8 @@ class MOSlurmSpawner(SlurmSpawner):
     async def submit_batch_script(self):
         self.log.info(f"Used environment: {self.user_options['environment_path']}")
         self.log.info(f"Used default URL: {self.default_url}")
+
+        # refresh environment to be kept in the job
+        self.req_keepvars = self._req_keepvars_default()
+
         return await super().submit_batch_script()

--- a/jupyterhub_moss/spawner.py
+++ b/jupyterhub_moss/spawner.py
@@ -80,7 +80,7 @@ class MOSlurmSpawner(SlurmSpawner):
 
     slurm_info_cmd = traitlets.Unicode(
         # Get number of nodes and cores for all partitions
-        r"sinfo -a -N --noheader -o \'%R %C %m\'",
+        r"sinfo -a -N --noheader -o '%R %t %m'",
         help="Command to query cluster information from Slurm. Formatted using req_xyz traits as {xyz}.",
     ).tag(config=True)
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,7 +23,7 @@ packages = find:
 include_package_data = True
 python_requires = >=3.8
 install_requires =
-    batchspawner
+    batchspawner>=1.0
     jinja2
     jupyterhub
     traitlets


### PR DESCRIPTION
We are using `jupyterhub_moss` in our cluster, but we found some trouble with the `sinfo` command. Please consider the following PR which addresses some of this issues.

Changelog:
1. The command `sinfo` is currently executed with `subprocess.check_output()`. However `batchspawner` already provides a more powerful `run_command()` that is asynchronous. This PR removes the dependency on `subprocess` to rely on `batchspawner`.
2. Added the option to easily customize the `sinfo` command
3. Prepend `SlurmSpawner.exec_prefix` to `sinfo`. Anything in `exec_prefix` needed to execute `sbatch` or `squeue`  will also be needed to execute `sinfo`.

