### PR TITLE
add option to define custom parser for slurm info command

### DIFF
--- a/jupyterhub_moss/spawner.py
+++ b/jupyterhub_moss/spawner.py
@@ -83,7 +83,7 @@ class MOSlurmSpawner(SlurmSpawner):
 
     slurm_info_cmd = traitlets.Unicode(
         # Get number of nodes, cores, gpus, total memory for all partitions
-        r"sinfo -a --noheader -o '%R %D %C %G %m'",
+        r"sinfo -a --noheader -o '%R %D %c %C %G %m'",
         help="Command to query cluster information from Slurm. Formatted using req_xyz traits as {xyz}."
         "Output will be parsed by ``slurm_info_resources``.",
     ).tag(config=True)

--- a/jupyterhub_moss/spawner.py
+++ b/jupyterhub_moss/spawner.py
@@ -126,7 +126,7 @@ class MOSlurmSpawner(SlurmSpawner):
             try:
                 gpus_gres = gpus.replace("(", ":").split(":")
                 gpus_total = gpus_gres[2]
-                gpu = ":".join(gpus_gres[0:1]) + ":{}"
+                gpu = ":".join(gpus_gres[0:2]) + ":{}"
             except IndexError:
                 gpus_total = 0
                 gpu = None

--- a/jupyterhub_moss/spawner.py
+++ b/jupyterhub_moss/spawner.py
@@ -97,6 +97,10 @@ class MOSlurmSpawner(SlurmSpawner):
     ).tag(config=True)
 
     @traitlets.default("slurm_info_resources")
+    def _get_slurm_info_resources_default(self):
+        """Returns default for `slurm_info_resources` traitlet."""
+        return self._slurm_info_resources
+
     def _slurm_info_resources(self, slurm_info_out):
         """
         Parses output from Slurm command: sinfo -a --noheader -o '%R %D %C %G %m'

--- a/jupyterhub_moss/spawner.py
+++ b/jupyterhub_moss/spawner.py
@@ -191,7 +191,7 @@ class MOSlurmSpawner(SlurmSpawner):
         out = await self.run_command(cmd)
 
         # Parse command output
-        resources_display, resources_info = self._slurm_info_resources(out)
+        resources_display, resources_info = self.slurm_info_resources(out)
         self.log.debug(
             "Slurm resources displayed in available resources: %s", resources_display
         )

--- a/jupyterhub_moss/spawner.py
+++ b/jupyterhub_moss/spawner.py
@@ -119,7 +119,7 @@ class MOSlurmSpawner(SlurmSpawner):
             lambda: {resource: 0 for resource in RESOURCES_COUNTS + resources_display}
         )
         for line in slurm_info_out.splitlines():
-            partition, nodes, cores, gpus, memory = line.split()
+            partition, nodes, ncores_per_node, cores, gpus, memory = line.split()
             # core count - allocated/idle/other/total
             _, cores_idle, _, cores_total = cores.split("/")
             # gpu count - gpu:name:total(indexes)

--- a/jupyterhub_moss/spawner.py
+++ b/jupyterhub_moss/spawner.py
@@ -138,8 +138,8 @@ class MOSlurmSpawner(SlurmSpawner):
                 count["Total Cores"] = int(cores_total)
                 count["Idle Cores"] = int(cores_idle)
                 # required resource counts
-                count["max_nprocs"] = int(ncores_per_node.rstrip('+'))
-                count["max_mem"] = int(memory.rstrip('+'))
+                count["max_nprocs"] = int(ncores_per_node.rstrip("+"))
+                count["max_mem"] = int(memory.rstrip("+"))
                 count["gpu"] = gpu
                 count["max_ngpus"] = int(gpus_total)
             except ValueError as err:

--- a/jupyterhub_moss/spawner.py
+++ b/jupyterhub_moss/spawner.py
@@ -138,7 +138,7 @@ class MOSlurmSpawner(SlurmSpawner):
                 count["Total Cores"] = int(cores_total)
                 count["Idle Cores"] = int(cores_idle)
                 # required resource counts
-                count["max_nprocs"] = count["Total Cores"] / count["Total Nodes"]
+                count["max_nprocs"] = int(ncores_per_node.rstrip('+'))
                 count["max_mem"] = int(memory)
                 count["gpu"] = gpu
                 count["max_ngpus"] = int(gpus_total)

--- a/jupyterhub_moss/spawner.py
+++ b/jupyterhub_moss/spawner.py
@@ -80,7 +80,7 @@ class MOSlurmSpawner(SlurmSpawner):
 
     slurm_info_cmd = traitlets.Unicode(
         # Get number of nodes and cores for all partitions
-        r"sinfo -a -N --noheader -o '%R %t %m'",
+        r"sinfo -a -N --noheader -o '%R %C %m'",
         help="Command to query cluster information from Slurm. Formatted using req_xyz traits as {xyz}.",
     ).tag(config=True)
 
@@ -110,16 +110,18 @@ class MOSlurmSpawner(SlurmSpawner):
                 format_template(self.slurm_info_cmd, **subvars),
             )
         )
-        self.log.info("Slurm info command: %s", cmd)
-        state = await self.run_command(cmd)
-        slurm_info = defaultdict(lambda: {"nodes": 0, "idle": 0, "max_mem": 0})
-        for line in state.splitlines():
-            partition, state, memory = line.split()
+        self.log.debug("Slurm info command: %s", cmd)
+        out = await self.run_command(cmd)
+        slurm_info = defaultdict(lambda: {"nodes": 0, "cores_total": 0, "cores_idle":0, "max_mem": 0})
+        for line in out.splitlines():
+            partition, cores, memory = line.split()
+            _, cores_idle, _, cores_total = cores.split('/')
             info = slurm_info[partition]
             info["nodes"] += 1
-            if state == "idle":
-                info["idle"] += 1
+            info["cores_total"] += int(cores_total)
+            info["cores_idle"] += int(cores_idle)
             info["max_mem"] = max(info["max_mem"], int(memory))
+        self.log.debug("Slurm info totals: %s", slurm_info)
         return slurm_info
 
     @staticmethod
@@ -128,22 +130,21 @@ class MOSlurmSpawner(SlurmSpawner):
         slurm_info = await spawner._get_slurm_info()
 
         # Combine all partition info as a dict
-        partitions = {}
+        partition_info = {}
         default_partition = None
-        for name, info in spawner.partitions.items():
-            partitions[name] = {
-                "max_nnodes": slurm_info[name]["nodes"],
-                "nnodes_idle": slurm_info[name]["idle"],
-                "max_mem": slurm_info[name]["max_mem"],
-                **info,
-            }
-            if info["simple"] and default_partition is None:
-                default_partition = name
+        for partition in spawner.partitions:
+            avail_partition = {}
+            avail_partition.update(spawner.partitions[partition])
+            avail_partition.update(slurm_info[partition])
+            partition_info[partition] = avail_partition
+
+            if avail_partition["simple"] and default_partition is None:
+                default_partition = partition
 
         # Prepare json info
         jsondata = json.dumps(
             {
-                "partitions": partitions,
+                "partitions": partition_info,
                 "default_partition": default_partition,
             }
         )
@@ -151,7 +152,7 @@ class MOSlurmSpawner(SlurmSpawner):
         return spawner.FORM_TEMPLATE.render(
             hash_option_form_css=RESOURCES_HASH["option_form.css"],
             hash_option_form_js=RESOURCES_HASH["option_form.js"],
-            partitions=partitions,
+            partitions=partition_info,
             default_partition=default_partition,
             batchspawner_version=BATCHSPAWNER_VERSION,
             jupyterhub_version=JUPYTERHUB_VERSION,

--- a/jupyterhub_moss/spawner.py
+++ b/jupyterhub_moss/spawner.py
@@ -139,7 +139,7 @@ class MOSlurmSpawner(SlurmSpawner):
                 count["Idle Cores"] = int(cores_idle)
                 # required resource counts
                 count["max_nprocs"] = int(ncores_per_node.rstrip('+'))
-                count["max_mem"] = int(memory)
+                count["max_mem"] = int(memory.rstrip('+'))
                 count["gpu"] = gpu
                 count["max_ngpus"] = int(gpus_total)
             except ValueError as err:

--- a/jupyterhub_moss/templates/option_form.html
+++ b/jupyterhub_moss/templates/option_form.html
@@ -128,7 +128,7 @@ window.SLURM_DATA = JSON.parse('{{ jsondata }}');
     <table class="table table-hover">
       <tr class="active">
         <th>Partition</th>
-        {% for res_name in resources_labels %}
+        {% for res_name in resources_display %}
         <th>{{ res_name }}</th>
         {% endfor %}
       </tr>
@@ -136,7 +136,7 @@ window.SLURM_DATA = JSON.parse('{{ jsondata }}');
       {% if partition.simple %}
       <tr>
         <th>{{ name }}</th>
-        {% for res in partition['resources_info'] %}
+        {% for res in partition['available_counts'] %}
         <td>{{ res }}</td>
         {% endfor %}
       </tr>
@@ -290,14 +290,14 @@ window.SLURM_DATA = JSON.parse('{{ jsondata }}');
     <table class="table table-hover">
       <tr class="active">
         <th>Partition</th>
-        {% for res_name in resources_labels %}
+        {% for res_name in resources_display %}
         <th>{{ res_name }}</th>
         {% endfor %}
       </tr>
       {% for name, partition in partitions.items() %}
       <tr>
         <th>{{ name }}</th>
-        {% for res in partition['resources_info'] %}
+        {% for res in partition['available_counts'] %}
         <td>{{ res }}</td>
         {% endfor %}
       </tr>

--- a/jupyterhub_moss/templates/option_form.html
+++ b/jupyterhub_moss/templates/option_form.html
@@ -128,17 +128,17 @@ window.SLURM_DATA = JSON.parse('{{ jsondata }}');
     <table class="table table-hover">
       <tr class="active">
         <th>Partition</th>
-        <th>Total Nodes</th>
-        <th>Toral Cores</th>
-        <th>Idle Cores</th>
+        {% for res_name in resources_labels %}
+        <th>{{ res_name }}</th>
+        {% endfor %}
       </tr>
       {% for name, partition in partitions.items() %}
       {% if partition.simple %}
       <tr>
         <th>{{ name }}</th>
-        <td>{{ partition.nodes }}</td>
-        <td>{{ partition.cores_total }}</td>
-        <td>{{ partition.cores_idle }}</td>
+        {% for res in partition['resources_info'] %}
+        <td>{{ res }}</td>
+        {% endfor %}
       </tr>
       {% endif %}
       {% endfor %}
@@ -290,16 +290,16 @@ window.SLURM_DATA = JSON.parse('{{ jsondata }}');
     <table class="table table-hover">
       <tr class="active">
         <th>Partition</th>
-        <th>Total Nodes</th>
-        <th>Toral Cores</th>
-        <th>Idle Cores</th>
+        {% for res_name in resources_labels %}
+        <th>{{ res_name }}</th>
+        {% endfor %}
       </tr>
       {% for name, partition in partitions.items() %}
       <tr>
         <th>{{ name }}</th>
-        <td>{{ partition.nodes }}</td>
-        <td>{{ partition.cores_total }}</td>
-        <td>{{ partition.cores_idle }}</td>
+        {% for res in partition['resources_info'] %}
+        <td>{{ res }}</td>
+        {% endfor %}
       </tr>
       {% endfor %}
     </table>

--- a/jupyterhub_moss/templates/option_form.html
+++ b/jupyterhub_moss/templates/option_form.html
@@ -124,24 +124,21 @@ window.SLURM_DATA = JSON.parse('{{ jsondata }}');
         <option value="12">12 hours</option>
       </select>
     </div>
-    <h4 style="text-align: center">List of available resources:</h4>
-    <table width="100%" border="1" style="text-align: center">
-      <tr style="text-align: center; background-color: orange">
-        <th style="text-align: center" colspan="6">Current Status</th>
+    <h4 style="text-align: left">Available resources at current time</h4>
+    <table class="table table-hover">
+      <tr class="active">
+        <th>Partition</th>
+        <th>Total Nodes</th>
+        <th>Toral Cores</th>
+        <th>Idle Cores</th>
       </tr>
-
-      <tr style="text-align: center; background-color: gold">
-        <th style="text-align: center">Partition</th>
-        <th style="text-align: center"># nodes</th>
-        <th style="text-align: center"># avail</th>
-      </tr>
-
       {% for name, partition in partitions.items() %}
       {% if partition.simple %}
       <tr>
-        <th style="text-align: center">{{ name }}</th>
-        <td>{{ partition.max_nnodes }}</td>
-        <td>{{ partition.nnodes_idle }}</td>
+        <th>{{ name }}</th>
+        <td>{{ partition.nodes }}</td>
+        <td>{{ partition.cores_total }}</td>
+        <td>{{ partition.cores_idle }}</td>
       </tr>
       {% endif %}
       {% endfor %}
@@ -289,21 +286,20 @@ window.SLURM_DATA = JSON.parse('{{ jsondata }}');
     />
     </div>
 
-    <h4 style="text-align: center">List of available resources:</h4>
-    <table width="100%" border="1" style="text-align: center">
-      <tr style="text-align: center; background-color: orange">
-        <th style="text-align: center" colspan="6">Current Status</th>
-      </tr>
-      <tr style="text-align: center; background-color: gold">
-        <th style="text-align: center">Partition</th>
-        <th style="text-align: center"># nodes</th>
-        <th style="text-align: center"># avail</th>
+    <h4 style="text-align: left">Available resources at current time</h4>
+    <table class="table table-hover">
+      <tr class="active">
+        <th>Partition</th>
+        <th>Total Nodes</th>
+        <th>Toral Cores</th>
+        <th>Idle Cores</th>
       </tr>
       {% for name, partition in partitions.items() %}
       <tr>
-        <th style="text-align: center">{{ name }}</th>
-        <td>{{ partition.max_nnodes }}</td>
-        <td>{{ partition.nnodes_idle }}</td>
+        <th>{{ name }}</th>
+        <td>{{ partition.nodes }}</td>
+        <td>{{ partition.cores_total }}</td>
+        <td>{{ partition.cores_idle }}</td>
       </tr>
       {% endfor %}
     </table>


### PR DESCRIPTION
Follow-up to https://github.com/silx-kit/jupyterhub_moss/pull/64#discussion_r1026373123 and https://github.com/silx-kit/jupyterhub_moss/pull/64#discussion_r1026507052

This PR got a bit bigger than intended. Apologies, I wanted to get to a point where no functionality was lost or broken.

It has 3 main changes:
1. add option `slurm_info_resources` to define custom parser for `slurm_info_cmd`, this is kept as a separate option to be able to have an intermediate method `_get_slurm_info_resources()` that can do templating and error check
2. configuration options `max_nprocs`, `max_ngpus`, `max_mem` are now optional, they will be queried to Slurm by default and can be overwritten in the configuration file
3. table of available resources modified to handle any data columns defined in `slurm_info_resources` and style simplified by using the embedded bootstrap classes in JupyterHub 

As far as I can tell there are no breaking changes, existing configuration files should continue to work.

closes #17