### PR TITLE
Retrieve time limit from SLURM

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,19 +102,23 @@ c.MOSlurmSpawner.partitions = {
   will be used to generate subtitles in the spawn page.
 - `description`: The description of the partition. This is only cosmetic and
   will be used to generate subtitles in the spawn page.
-- `gpu`: A template string that will be used to request GPU resources through
-  `--gres`. The template should therefore include a `{}` that will be replaced
-  by the number of requested GPU **and** follow the format expected by `--gres`.
-  If no GPU is available for this partition, set to `None`.
-- `max_ngpus`: The maximum number of GPU that can be requested for this
-  partition. The spawn page will use this to generate appropriate bounds for the
-  user inputs. If no GPU is available for this partition, set to `0`.
-- `max_nprocs`: The maximum number of processors that can be requested for this
-  partition. The spawn page will use this to generate appropriate bounds for the
-  user inputs.
-- `max_runtime`: The maximum job runtime for this partition in seconds. It
-  should be of minimum 1 hour as the _Simple_ tab only display buttons for
-  runtimes greater than 1 hour.
+- `gpu`: [Optional] A template string that will be used to request GPU resources
+  through `--gres`. The template should therefore include a `{}` that will be
+  replaced by the number of requested GPU **and** follow the format expected by
+  `--gres`. If no GPU is available for this partition, set to `None`. It is
+  retrieved from SLURM if not provided.
+- `max_ngpus`: [Optional] The maximum number of GPU that can be requested for
+  this partition. The spawn page will use this to generate appropriate bounds
+  for the user inputs. If no GPU is available for this partition, set to `0`. It
+  is retrieved from SLURM if not provided.
+- `max_nprocs`: [Optional] The maximum number of processors that can be
+  requested for this partition. The spawn page will use this to generate
+  appropriate bounds for the user inputs. It is retrieved from SLURM if not
+  provided.
+- `max_runtime`: [Optional] The maximum job runtime for this partition in
+  seconds. It should be of minimum 1 hour as the _Simple_ tab only display
+  buttons for runtimes greater than 1 hour. It is retrieved from SLURM if not
+  provided.
 - `simple`: Whether the partition should be available in the _Simple_ tab. The
   spawn page that will be generated is organized in a two tabs: a _Simple_ tab
   with minimal settings that will be enough for most users and an _Advanced_ tab

--- a/demo_jupyterhub_conf.py
+++ b/demo_jupyterhub_conf.py
@@ -1,14 +1,11 @@
 # Sample jupyterhub configuration using jupyterhub_moss
 
 import os
-import random
 import sys
-
-import batchspawner  # noqa
 
 sys.path.insert(0, os.path.abspath(os.path.dirname(__file__)))
 
-import jupyterhub_moss  # noqa
+import jupyterhub_moss
 
 c = get_config()  # noqa
 
@@ -16,28 +13,21 @@ c = get_config()  # noqa
 jupyterhub_moss.set_config(c)
 
 
-class MOckSlurmSpawner(jupyterhub_moss.MOSlurmSpawner):
-    async def _get_slurm_info(self):
-        return {
-            k: {
-                "nodes": v["max_nprocs"],
-                "idle": random.randint(0, v["max_nprocs"]),
-                "max_mem": 128000 * (index + 1),
-            }
-            for index, (k, v) in enumerate(self.partitions.items())
-        }
+SINFO_OUTPUT = """unused 40 28+ 121/1191/0/1312 (null) 196000+
+partition_1 48 35+ 38/1642/0/1680 (null) 196000+
+partition_2 7 128 116/780/0/896 gpu:GPU-MODEL:2 512000
+partition_3 28 40 114/1006/0/1120 (null) 310000
+other_mixed 10 64 152/488/0/640 gpu:OTHER-GPU:2(S:0-1) 455000+
+other_mixed 94 28+ 153/3583/0/3736 (null) 196000+
+"""
+c.MOSlurmSpawner.slurm_info_cmd = f'echo "{SINFO_OUTPUT}"'
 
-
-c.JupyterHub.spawner_class = MOckSlurmSpawner
 
 # Partition descriptions, see https://github.com/silx-kit/jupyterhub_moss#partition-settings
 c.MOSlurmSpawner.partitions = {
     "partition_1": {
         "architecture": "x86_86",
         "description": "Partition 1",
-        "gpu": None,
-        "max_ngpus": 0,
-        "max_nprocs": 28,
         "max_runtime": 12 * 3600,
         "simple": True,
         "jupyter_environments": {
@@ -60,9 +50,6 @@ c.MOSlurmSpawner.partitions = {
     "partition_2": {
         "architecture": "ppc64le",
         "description": "Partition 2",
-        "gpu": "gpu:V100-SXM2-32GB:{}",
-        "max_ngpus": 2,
-        "max_nprocs": 128,
         "max_runtime": 1 * 3600,
         "simple": True,
         "jupyter_environments": {
@@ -83,9 +70,6 @@ c.MOSlurmSpawner.partitions = {
     "partition_3": {
         "architecture": "x86_86",
         "description": "Partition 3",
-        "gpu": None,
-        "max_ngpus": 0,
-        "max_nprocs": 28,
         "max_runtime": 12 * 3600,
         "simple": False,
         "jupyter_environments": {

--- a/demo_jupyterhub_conf.py
+++ b/demo_jupyterhub_conf.py
@@ -5,7 +5,7 @@ import sys
 
 sys.path.insert(0, os.path.abspath(os.path.dirname(__file__)))
 
-import jupyterhub_moss
+import jupyterhub_moss  # noqa
 
 c = get_config()  # noqa
 
@@ -13,12 +13,12 @@ c = get_config()  # noqa
 jupyterhub_moss.set_config(c)
 
 
-SINFO_OUTPUT = """unused 40 28+ 121/1191/0/1312 (null) 196000+
-partition_1 48 35+ 38/1642/0/1680 (null) 196000+
-partition_2 7 128 116/780/0/896 gpu:GPU-MODEL:2 512000
-partition_3 28 40 114/1006/0/1120 (null) 310000
-other_mixed 10 64 152/488/0/640 gpu:OTHER-GPU:2(S:0-1) 455000+
-other_mixed 94 28+ 153/3583/0/3736 (null) 196000+
+SINFO_OUTPUT = """unused 40 28+ 121/1191/0/1312 (null) 196000+ infinite
+partition_1 48 35+ 38/1642/0/1680 (null) 196000+ 1-00:00:00
+partition_2 7 128 116/780/0/896 gpu:GPU-MODEL:2 512000 12:00:00
+partition_3 28 40 114/1006/0/1120 (null) 310000 4:00:00
+other_mixed 10 64 152/488/0/640 gpu:OTHER-GPU:2(S:0-1) 455000+ 7-00:00:00
+other_mixed 94 28+ 153/3583/0/3736 (null) 196000+ 7-00:00:00
 """
 c.MOSlurmSpawner.slurm_info_cmd = f'echo "{SINFO_OUTPUT}"'
 
@@ -28,7 +28,6 @@ c.MOSlurmSpawner.partitions = {
     "partition_1": {
         "architecture": "x86_86",
         "description": "Partition 1",
-        "max_runtime": 12 * 3600,
         "simple": True,
         "jupyter_environments": {
             "default": {
@@ -50,7 +49,6 @@ c.MOSlurmSpawner.partitions = {
     "partition_2": {
         "architecture": "ppc64le",
         "description": "Partition 2",
-        "max_runtime": 1 * 3600,
         "simple": True,
         "jupyter_environments": {
             "default": {
@@ -70,7 +68,6 @@ c.MOSlurmSpawner.partitions = {
     "partition_3": {
         "architecture": "x86_86",
         "description": "Partition 3",
-        "max_runtime": 12 * 3600,
         "simple": False,
         "jupyter_environments": {
             "default": {

--- a/jupyterhub_moss/spawner.py
+++ b/jupyterhub_moss/spawner.py
@@ -22,7 +22,14 @@ RESOURCES_HASH = {
 }
 
 # Required resources per partition
-RESOURCES_COUNTS = ["max_nprocs", "max_mem", "gpu", "max_ngpus", "max_runtime", "available_counts"]
+RESOURCES_COUNTS = [
+    "max_nprocs",
+    "max_mem",
+    "gpu",
+    "max_ngpus",
+    "max_runtime",
+    "available_counts",
+]
 
 with open(local_path("batch_script.sh")) as f:
     BATCH_SCRIPT = f.read()
@@ -121,7 +128,15 @@ class MOSlurmSpawner(SlurmSpawner):
             lambda: {resource: 0 for resource in RESOURCES_COUNTS + resources_display}
         )
         for line in slurm_info_out.splitlines():
-            partition, nodes, ncores_per_node, cores, gpus, memory, timelimit = line.split()
+            (
+                partition,
+                nodes,
+                ncores_per_node,
+                cores,
+                gpus,
+                memory,
+                timelimit,
+            ) = line.split()
             # core count - allocated/idle/other/total
             _, cores_idle, _, cores_total = cores.split("/")
             # gpu count - gpu:name:total(indexes)
@@ -283,8 +298,9 @@ class MOSlurmSpawner(SlurmSpawner):
 
         if "runtime" in options:
             runtime = parse_timelimit(options["runtime"])
-            assert runtime is not None, "Error in runtime syntax"
-            assert runtime.total_seconds() <=  partition_info["max_runtime"], "Requested runtime exceeds partition time limit"
+            assert (
+                runtime.total_seconds() <= partition_info["max_runtime"]
+            ), "Requested runtime exceeds partition time limit"
 
         if (
             "nprocs" in options

--- a/jupyterhub_moss/spawner.py
+++ b/jupyterhub_moss/spawner.py
@@ -133,9 +133,12 @@ class MOSlurmSpawner(SlurmSpawner):
                 gpus_total = 0
                 gpu = None
 
-            max_runtime = parse_timelimit(timelimit)
-            if max_runtime is None:
-                # Parsing failed: Limit to one day
+            try:
+                max_runtime = parse_timelimit(timelimit)
+            except ValueError:
+                self.log.warning(
+                    f"Parsing timelimit '{timelimit}' failed: set to 1 day"
+                )
                 max_runtime = datetime.timedelta(days=1)
 
             count = resources_count[partition]

--- a/jupyterhub_moss/templates/option_form.html
+++ b/jupyterhub_moss/templates/option_form.html
@@ -125,7 +125,7 @@ window.SLURM_DATA = JSON.parse('{{ jsondata }}');
       </select>
     </div>
     <h4 style="text-align: left">Available resources at current time</h4>
-    <table class="table table-hover">
+    <table class="table">
       <tr class="active">
         <th>Partition</th>
         {% for res_name in resources_display %}
@@ -287,7 +287,7 @@ window.SLURM_DATA = JSON.parse('{{ jsondata }}');
     </div>
 
     <h4 style="text-align: left">Available resources at current time</h4>
-    <table class="table table-hover">
+    <table class="table">
       <tr class="active">
         <th>Partition</th>
         {% for res_name in resources_display %}

--- a/jupyterhub_moss/utils.py
+++ b/jupyterhub_moss/utils.py
@@ -21,6 +21,7 @@ def find(function: Callable[[Any], bool], iterable: Iterable[Any]) -> Optional[A
             return item
     return None
 
+
 _TIMELIMIT_REGEXP = re.compile(
     "^(?:^(?P<days>[0-9]+)-)?(?P<hours>[0-9]+)(?::(?P<minutes>[0-5]?[0-9]))?(?::(?P<seconds>[0-5]?[0-9]))?$"
 )

--- a/jupyterhub_moss/utils.py
+++ b/jupyterhub_moss/utils.py
@@ -31,6 +31,8 @@ def parse_timelimit(timelimit: str) -> datetime.timedelta:
 
     Raises ValueError if parsing failed.
     """
+    if timelimit == "infinite":
+        return datetime.timedelta.max
     match = _TIMELIMIT_REGEXP.match(timelimit)
     if match is None:
         raise ValueError(f"Failed to parse time limit: '{timelimit}'.")

--- a/jupyterhub_moss/utils.py
+++ b/jupyterhub_moss/utils.py
@@ -26,14 +26,14 @@ _TIMELIMIT_REGEXP = re.compile(
 )
 
 
-def parse_timelimit(timelimit: str) -> Optional[datetime.timedelta]:
+def parse_timelimit(timelimit: str) -> datetime.timedelta:
     """Parse a SLURM timelimit/walltime string.
 
-    Returns a timedelta or None if parsing failed.
+    Raises ValueError if parsing failed.
     """
     match = _TIMELIMIT_REGEXP.match(timelimit)
     if match is None:
-        return None
+        raise ValueError(f"Failed to parse time limit: '{timelimit}'.")
     return datetime.timedelta(
         **{k: int(v) for k, v in match.groupdict().items() if v is not None}
     )

--- a/jupyterhub_moss/utils.py
+++ b/jupyterhub_moss/utils.py
@@ -1,5 +1,7 @@
+import datetime
 import hashlib
 import os.path
+import re
 from typing import Any, Callable, Iterable, Optional
 
 
@@ -18,3 +20,20 @@ def find(function: Callable[[Any], bool], iterable: Iterable[Any]) -> Optional[A
         if function(item):
             return item
     return None
+
+_TIMELIMIT_REGEXP = re.compile(
+    "^(?:^(?P<days>[0-9]+)-)?(?P<hours>[0-9]+)(?::(?P<minutes>[0-5]?[0-9]))?(?::(?P<seconds>[0-5]?[0-9]))?$"
+)
+
+
+def parse_timelimit(timelimit: str) -> Optional[datetime.timedelta]:
+    """Parse a SLURM timelimit/walltime string.
+
+    Returns a timedelta or None if parsing failed.
+    """
+    match = _TIMELIMIT_REGEXP.match(timelimit)
+    if match is None:
+        return None
+    return datetime.timedelta(
+        **{k: int(v) for k, v in match.groupdict().items() if v is not None}
+    )


### PR DESCRIPTION
This PR adds retrieval of time limit from SLURM so it is no longer required to pass it in the config.
This is now possible thanks to PR #66

It also does some follow-ups of #66: updates the README to mark some config as optional, and updates the demo config file to work with the new spawner and removes the hover from the resources table since it is not interactive.