### PR TITLE
Fix inconsistency of `partitions` info and remove `options_from_form` side-effects

### DIFF
--- a/jupyterhub_moss/spawner.py
+++ b/jupyterhub_moss/spawner.py
@@ -308,7 +308,7 @@ class MOSlurmSpawner(SlurmSpawner):
         if "reservation" in options and "\n" in options["reservation"]:
             raise AssertionError("Error in reservation")
 
-        if "ngpus" in options and not 0 <= options["ngpus"]:
+        if "ngpus" in options and options["ngpus"] < 0:
             raise AssertionError("Error: Number of GPUs must be positive")
 
         if "options" in options and "\n" in options["options"]:

--- a/jupyterhub_moss/spawner.py
+++ b/jupyterhub_moss/spawner.py
@@ -415,6 +415,7 @@ class MOSlurmSpawner(SlurmSpawner):
 
         # Specific handling of landing URL (e.g., to start jupyterlab)
         self.default_url = self.user_options.get("default_url", "")
+        self.log.info(f"Used default URL: {self.default_url}")
 
         if "root_dir" in self.user_options:
             self.notebook_dir = self.user_options["root_dir"]
@@ -427,14 +428,13 @@ class MOSlurmSpawner(SlurmSpawner):
                 raise RuntimeError("GPU(s) not available for this partition")
             self.user_options["gres"] = gpu_gres_template.format(ngpus)
 
-        self.__update_spawn_commands(self.user_options["environment_path"])
+        environment_path = self.user_options["environment_path"]
+        self.log.info(f"Used environment: {environment_path}")
+        self.__update_spawn_commands(environment_path)
 
         return await super().start()
 
     async def submit_batch_script(self):
-        self.log.info(f"Used environment: {self.user_options['environment_path']}")
-        self.log.info(f"Used default URL: {self.default_url}")
-
         # refresh environment to be kept in the job
         self.req_keepvars = self.trait_defaults("req_keepvars")
 


### PR DESCRIPTION
This PR aims at fixing the inconsistency raised in #70 and also aims at complying to `options_from_form` documented behavior:
```
        This method should not have any side effects.
        Any handling of `user_options` should be done in `.start()`
        to ensure consistent behavior across servers
        spawned via the API and form submission page.
```
https://github.com/jupyterhub/jupyterhub/blob/3491ad68162cd52c198a3732a50ad6cee5a8bf2c/jupyterhub/spawner.py#L542-L545

It uses `_get_partitions_info` instead of `self.partitions` to always retrieve the info from SLURM rather than expecting that this was already done.
This function combines information from SLURM with `self.partitions` to keep the option to override information from SLURM.

All checks requiring partition limits are moved to `start` (`options_from_form` cannot be async).
All attribute updates are also moved to `start` to comply with `options_from_form` documentation.

closes #70