### PR TITLE
Add per-environment `prologue`

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ c.MOSlurmSpawner.partitions = {
                 "path": "/env/path/bin/",  # Path to Python environment bin/ used to start jupyter on the Slurm nodes
                 "description": "Default",  # Text displayed for this environment select option
                 "add_to_path": True,       # Toggle adding the environment to shell PATH (optional, default: True)
+                "prologue": "",            # Shell commands to execute before starting the Jupyter server (optional, default: "")
             },
         },
     },
@@ -75,6 +76,7 @@ c.MOSlurmSpawner.partitions = {
                 "path": "/path/to/jupyter/env/for/partition_2/bin/",
                 "description": "Default",
                 "add_to_path": True,
+                "prologue": "echo 'Starting default environment'",
             },
         },
     },
@@ -91,6 +93,7 @@ c.MOSlurmSpawner.partitions = {
                 "path": "/path/to/jupyter/env/for/partition_3/bin/",
                 "description": "Partition 3 default",
                 "add_to_path": True,
+                "prologue": "echo 'Starting default environment'",
         },
     },
 }
@@ -134,6 +137,10 @@ c.MOSlurmSpawner.partitions = {
   - `description`: Text used for display in the selection options.
   - `add_to_path`: Whether or not to prepend the environment `path` to shell
     `PATH`.
+  - `prologue`: Shell commands to execute on the Slurm node before starting the
+    Jupyter single-user server. This can be used to run, e.g.,
+    `module load <module>`. By default no command is run. This is appended to
+    commands passed through batchspawner's `req_prologue`.
 
 ### Spawn page
 

--- a/README.md
+++ b/README.md
@@ -139,8 +139,7 @@ c.MOSlurmSpawner.partitions = {
     `PATH`.
   - `prologue`: Shell commands to execute on the Slurm node before starting the
     Jupyter single-user server. This can be used to run, e.g.,
-    `module load <module>`. By default no command is run. This is appended to
-    commands passed through batchspawner's `req_prologue`.
+    `module load <module>`. By default no command is run.
 
 ### Spawn page
 

--- a/demo_jupyterhub_conf.py
+++ b/demo_jupyterhub_conf.py
@@ -34,15 +34,18 @@ c.MOSlurmSpawner.partitions = {
                 "path": "/default/jupyter_env_path/bin/",
                 "description": "Operating system (default)",
                 "add_to_path": False,
+                "prologue": 'echo "Starting default env."\n',
             },
             "new-x86": {
                 "path": "/new-x86/jupyter_env_path/bin/",
                 "description": "New environment x86 (latest)",
                 "add_to_path": True,
+                "prologue": "echo 'Starting new-x86 env.'",
             },
             "latest": {
                 "path": "/latest/jupyter_env_path/bin/",
                 "description": "Operating system (latest)",
+                "prologue": "echo 'Starting latest env.'",
             },
         },
     },

--- a/jupyterhub_moss/spawner.py
+++ b/jupyterhub_moss/spawner.py
@@ -66,7 +66,7 @@ class MOSlurmSpawner(SlurmSpawner):
                             "path": traitlets.Unicode(),
                             "description": traitlets.Unicode(),
                             "add_to_path": traitlets.Bool(),
-                            "prologue": traitlets.Unicode(default_value=""),
+                            "prologue": traitlets.Unicode(),
                         },
                     ),
                 ),

--- a/jupyterhub_moss/spawner.py
+++ b/jupyterhub_moss/spawner.py
@@ -66,6 +66,7 @@ class MOSlurmSpawner(SlurmSpawner):
                             "path": traitlets.Unicode(),
                             "description": traitlets.Unicode(),
                             "add_to_path": traitlets.Bool(),
+                            "prologue": traitlets.Unicode(default_value=""),
                         },
                     ),
                 ),
@@ -86,6 +87,7 @@ class MOSlurmSpawner(SlurmSpawner):
         for partition in partitions.values():
             for env in partition["jupyter_environments"].values():
                 env.setdefault("add_to_path", True)
+                env.setdefault("prologue", "")
         return partitions
 
     slurm_info_cmd = traitlets.Unicode(
@@ -240,7 +242,8 @@ class MOSlurmSpawner(SlurmSpawner):
             for partition, config_partition_info in self.partitions.items()
         }
 
-        return (resources_display, partitions_info)
+        # Ensure returning a dict that can be modified by the callers
+        return (resources_display, deepcopy(partitions_info))
 
     @staticmethod
     async def create_options_form(spawner):
@@ -253,6 +256,12 @@ class MOSlurmSpawner(SlurmSpawner):
         if not simple_partitions:
             raise RuntimeError("No 'simple' partition defined: No default partition")
         default_partition = simple_partitions[0]
+
+        # Strip prologue from partitions_info:
+        # it is not useful and can cause some parsing issues
+        for partition_info in partitions_info.values():
+            for env_info in partition_info["jupyter_environments"].values():
+                env_info.pop("prologue", None)
 
         # Prepare json info
         jsondata = json.dumps(
@@ -358,20 +367,27 @@ class MOSlurmSpawner(SlurmSpawner):
             # Set path to use from first environment for the current partition
             options["environment_path"] = partition_environments[0]["path"]
 
-        # Singularity images are never added to PATH
-        if options["environment_path"].endswith(".sif"):
-            return options
-
-        # Custom envs are always added to PATH, defaults ones only if add_to_path is True
         corresponding_default_env = find(
             lambda env: env["path"] == options["environment_path"],
             partition_environments,
         )
-        if (
+
+        # Generate prologue
+        prologue = self.req_prologue
+
+        if corresponding_default_env is not None:
+            prologue += f"\n{corresponding_default_env['prologue']}"
+
+        # Singularity images are never added to PATH
+        # Custom envs are always added to PATH
+        # Defaults envs only if add_to_path is True
+        if not options["environment_path"].endswith(".sif") and (
             corresponding_default_env is None
             or corresponding_default_env["add_to_path"]
         ):
-            options["prologue"] = f"export PATH={options['environment_path']}:$PATH"
+            prologue += f"\nexport PATH={options['environment_path']}:$PATH"
+
+        options["prologue"] = prologue
 
         return options
 

--- a/jupyterhub_moss/utils.py
+++ b/jupyterhub_moss/utils.py
@@ -40,3 +40,28 @@ def parse_timelimit(timelimit: str) -> datetime.timedelta:
     return datetime.timedelta(
         **{k: int(v) for k, v in match.groupdict().items() if v is not None}
     )
+
+
+def create_prologue(
+    default_prologue: str,
+    environment_path: str,
+    partition_environments,
+) -> str:
+    """Create prologue commands"""
+    prologue = default_prologue
+
+    corresponding_default_env = find(
+        lambda env: env["path"] == environment_path,
+        partition_environments,
+    )
+    if corresponding_default_env is not None:
+        prologue += f"\n{corresponding_default_env['prologue']}"
+
+    # Singularity images are never added to PATH
+    # Custom envs are always added to PATH
+    # Defaults envs only if add_to_path is True
+    if not environment_path.endswith(".sif") and (
+        corresponding_default_env is None or corresponding_default_env["add_to_path"]
+    ):
+        prologue += f"\nexport PATH={environment_path}:$PATH"
+    return prologue

--- a/jupyterhub_moss/utils.py
+++ b/jupyterhub_moss/utils.py
@@ -45,7 +45,7 @@ def parse_timelimit(timelimit: str) -> datetime.timedelta:
 def create_prologue(
     default_prologue: str,
     environment_path: str,
-    partition_environments,
+    partition_environments: Iterable[dict],
 ) -> str:
     """Create prologue commands"""
     prologue = default_prologue
@@ -58,10 +58,11 @@ def create_prologue(
         prologue += f"\n{corresponding_default_env['prologue']}"
 
     # Singularity images are never added to PATH
+    if environment_path.endswith(".sif"):
+        return prologue
+
     # Custom envs are always added to PATH
     # Defaults envs only if add_to_path is True
-    if not environment_path.endswith(".sif") and (
-        corresponding_default_env is None or corresponding_default_env["add_to_path"]
-    ):
+    if corresponding_default_env is None or corresponding_default_env["add_to_path"]:
         prologue += f"\nexport PATH={environment_path}:$PATH"
     return prologue


### PR DESCRIPTION
This PR adds a per-environment `prologue` config field so that commands can be added to the Slurm batch script.

closes #72