### PR TITLE
Allow to extend option_form template

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,11 +39,11 @@ and `black` to ensure CI passes.
 Even if you do not have access to a Slurm cluster, it is possible to mock the
 Slurm info to generate the spawn page for a local development JupyterHub
 instance. For instance, see the
-[`demo_jupyterhub_conf.py`](demo_jupyterhub_conf.py) file which which you can
+[`demo/jupyterhub_conf.py`](demo/jupyterhub_conf.py) file which which you can
 use to start jupyterhub using jupyterhub_moss:
 
 ```
-jupyterhub -f demo_jupyterhub_conf.py
+jupyterhub -f demo/jupyterhub_conf.py
 ```
 
 ## Release

--- a/demo/jupyterhub_conf.py
+++ b/demo/jupyterhub_conf.py
@@ -3,7 +3,7 @@
 import os
 import sys
 
-sys.path.insert(0, os.path.abspath(os.path.dirname(__file__)))
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 import jupyterhub_moss  # noqa
 

--- a/demo/jupyterhub_conf.py
+++ b/demo/jupyterhub_conf.py
@@ -90,6 +90,7 @@ c.MOSlurmSpawner.partitions = {
 c.JupyterHub.ip = "127.0.0.1"
 c.JupyterHub.hub_ip = "127.0.0.1"
 c.JupyterHub.port = 8000
+c.JupyterHub.template_paths = [os.path.join(os.path.dirname(__file__), "templates")]
 
 # Batchspawner
 c.BatchSpawnerBase.exec_prefix = ""  # Do not run sudo

--- a/demo/templates/option_form.html
+++ b/demo/templates/option_form.html
@@ -19,10 +19,10 @@
 </table>
 {% endmacro %}
 
-{% block simple_resource_table %}
+{% block simple_tab_footer %}
 resource_table(partitions, simple_only=true)
-{% endblock simple_resource_table %}
+{% endblock simple_tab_footer %}
 
-{% block resource_table %}
+{% block advanced_tab_footer %}
 resource_table(partitions)
-{% endblock resource_table %}
+{% endblock advanced_tab_footer %}

--- a/demo/templates/option_form.html
+++ b/demo/templates/option_form.html
@@ -1,0 +1,28 @@
+{% extends 'templates/option_form.html' %}
+{% macro resource_table(partitions, simple_only=false) -%}
+<h4 style="text-align: center">Available resources</h4>
+<table class="table">
+  <tr class="active">
+    <th>Partition</th>
+    <th>CPU cores</th>
+    <th>Nodes</th>
+  </tr>
+  {% for name, partition in partitions.items() %}
+  {% if partition.simple or not simple_only %}
+  <tr>
+    <th>{{ name }}</th>
+    <th>{{ partition['available_counts'][0] }}<small>/{{ partition['available_counts'][1] }}</small></th>
+    <th>{{ partition['available_counts'][2] }}</th>
+  </tr>
+  {% endif %}
+  {% endfor %}
+</table>
+{% endmacro %}
+
+{% block simple_resource_table %}
+resource_table(partitions, simple_only=true)
+{% endblock simple_resource_table %}
+
+{% block resource_table %}
+resource_table(partitions)
+{% endblock resource_table %}

--- a/jupyterhub_moss/templates/option_form.html
+++ b/jupyterhub_moss/templates/option_form.html
@@ -124,7 +124,7 @@ window.SLURM_DATA = JSON.parse('{{ jsondata }}');
         <option value="12">12 hours</option>
       </select>
     </div>
-    {% block simple_resource_table %}
+    {% block simple_tab_footer %}
     <h4 style="text-align: left">Available resources at current time</h4>
     <table class="table">
       <tr class="active">
@@ -144,7 +144,7 @@ window.SLURM_DATA = JSON.parse('{{ jsondata }}');
       {% endif %}
       {% endfor %}
     </table>
-    {% endblock simple_resource_table %}
+    {% endblock simple_tab_footer %}
   </div>
   <div id="menu1" class="tab-pane fade indent-right" align="right">
     <div class="form-container">
@@ -287,7 +287,7 @@ window.SLURM_DATA = JSON.parse('{{ jsondata }}');
       placeholder="--option1=v1 --option2=v2"
     />
     </div>
-    {% block resource_table %}
+    {% block advanced_tab_footer %}
     <h4 style="text-align: left">Available resources at current time</h4>
     <table class="table">
       <tr class="active">
@@ -305,6 +305,6 @@ window.SLURM_DATA = JSON.parse('{{ jsondata }}');
       </tr>
       {% endfor %}
     </table>
-    {% endblock resource_table %}
+    {% endblock advanced_tab_footer %}
   </div>
 </div>

--- a/jupyterhub_moss/templates/option_form.html
+++ b/jupyterhub_moss/templates/option_form.html
@@ -124,6 +124,7 @@ window.SLURM_DATA = JSON.parse('{{ jsondata }}');
         <option value="12">12 hours</option>
       </select>
     </div>
+    {% block simple_resource_table %}
     <h4 style="text-align: left">Available resources at current time</h4>
     <table class="table">
       <tr class="active">
@@ -143,6 +144,7 @@ window.SLURM_DATA = JSON.parse('{{ jsondata }}');
       {% endif %}
       {% endfor %}
     </table>
+    {% endblock simple_resource_table %}
   </div>
   <div id="menu1" class="tab-pane fade indent-right" align="right">
     <div class="form-container">
@@ -285,7 +287,7 @@ window.SLURM_DATA = JSON.parse('{{ jsondata }}');
       placeholder="--option1=v1 --option2=v2"
     />
     </div>
-
+    {% block resource_table %}
     <h4 style="text-align: left">Available resources at current time</h4>
     <table class="table">
       <tr class="active">
@@ -303,5 +305,6 @@ window.SLURM_DATA = JSON.parse('{{ jsondata }}');
       </tr>
       {% endfor %}
     </table>
+    {% endblock resource_table %}
   </div>
 </div>


### PR DESCRIPTION
This PR allows to extend the option_form jinja template in a similar way as jupyterhub allows to extends its templates.
For now, only 2 blocks can be overridden, but it is a generic approach and a lot more can be added if needed, up to the point of customizing it all....

This is a first step towards issue #73: It makes it possible to custom the displayed available resources without mixing it with `sinfo` parsing.
