### PR TITLE
Add first tests and set-up pytest

### DIFF
--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout 🏷️
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up Python 🐍
         uses: actions/setup-python@v2

--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -37,3 +37,16 @@ jobs:
 
       - name: check-manifest 📰
         run: check-manifest
+
+      - name: Install Node v16
+        uses: actions/setup-node@v3
+        with:
+          node-version: '16'
+
+      - name: Install configurable-http-proxy
+        run: |
+          npm install -g configurable-http-proxy
+          npm list
+
+      - name: pytest tests 👓
+        run: python -m pytest -v

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,7 +44,7 @@ Note: This is different from calling `pytest`, see
 
 The CI will check that the lint check passes, that all files are correctly
 formatted (using `black --check .`) and that tests passes. Before commiting, be
-sure to run `flake8` and `black` to ensure CI passes.
+sure to run `flake8`, `black` and `python -m pytest` to ensure CI passes.
 
 ## Generate the spawn page locally
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,11 +28,23 @@ manually using
 black .
 ```
 
+### Testing
+
+[pytest](https://docs.pytest.org/en/latest/) is used to run the tests. The
+config is located in `pyproject.toml`. Tests can be run using:
+
+```
+python -m pytest
+```
+
+Note: This is different from calling `pytest`, see
+[Invoking pytest versus python -m pytest](https://docs.pytest.org/en/latest/explanation/pythonpath.html#invoking-pytest-versus-python-m-pytest).
+
 ### CI
 
-The CI will check that the lint check passes and that all files are correctly
-formatted (using `black --check .`). Before commiting, be sure to run `flake8`
-and `black` to ensure CI passes.
+The CI will check that the lint check passes, that all files are correctly
+formatted (using `black --check .`) and that tests passes. Before commiting, be
+sure to run `flake8` and `black` to ensure CI passes.
 
 ## Generate the spawn page locally
 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,6 @@
 graft demo
 graft jupyterhub_moss
+graft test
 prune .vscode
 exclude .bumpversion.cfg
 exclude .editorconfig

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,3 +4,12 @@ requires = [
     "wheel"
 ]
 build-backend = "setuptools.build_meta"
+
+[tool.pytest.ini_options]
+addopts = [
+    "--import-mode=importlib",
+]
+asyncio_mode = "auto"
+testpaths = [
+  "test",
+]

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,11 +30,12 @@ install_requires =
 
 [options.extras_require]
 dev =
+    black
     build
     bump2version
     check-manifest
     flake8
-    black
+    jupyter_server
     pytest
     pytest-asyncio
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,6 +35,8 @@ dev =
     check-manifest
     flake8
     black
+    pytest
+    pytest-asyncio
 
 # E501 (line too long) ignored
 # E203 and W503 incompatible with black formatting (https://black.readthedocs.io/en/stable/compatible_configs.html#flake8)

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,0 +1,2 @@
+# Use jupyterhub's fixtures
+pytest_plugins = "jupyterhub.tests.conftest"

--- a/test/test_spawn_page.py
+++ b/test/test_spawn_page.py
@@ -1,0 +1,99 @@
+import json
+import re
+from unittest import mock
+
+from jupyterhub.tests.utils import get_page
+
+from .utils import MOSlurmSpawnerMock, post_request
+
+
+class MOSSMockSimple(MOSlurmSpawnerMock):
+    """MOSlurmSpawner with mocks and a simple configuration"""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        # Partition name, nnodes, ncores_per_node, ncores (allocated/idle/other/total), gpu, memory, timelimit
+        self.slurm_info_cmd = (
+            'echo "partition_1 48 35+ 38/1642/0/1680 (null) 196000+ 1-00:00:00"'
+        )
+
+        # Set partitions here so that validation is run
+        # Minimalistic default partitions config
+        self.partitions = {
+            "partition_1": {
+                "architecture": "x86_86",
+                "description": "Partition 1",
+                "simple": True,
+                "jupyter_environments": {
+                    "default": {
+                        "path": "/default/jupyter_env_path/bin/",
+                        "description": "default",
+                        "add_to_path": True,
+                    },
+                },
+            },
+        }
+
+
+async def test_spawn_page(app):
+    """Test display of spawn page and check embedded SLURM resources info"""
+    with mock.patch.dict(app.users.settings, {"spawner_class": MOSSMockSimple}):
+        cookies = await app.login_user("jones")
+        r = await get_page("spawn", app, cookies=cookies)
+
+        assert r.status_code == 200
+        assert r.url.endswith("/spawn")
+
+        match = re.search(r"window.SLURM_DATA = JSON.parse\('(?P<json>.*)'\)", r.text)
+        assert match is not None
+        slurm_data = json.loads(match.group("json"))
+
+        ref_partitions_info = {
+            "partition_1": {
+                "nnodes_total": 48,
+                "ncores_total": 1680,
+                "ncores_idle": 1642,
+                "max_nprocs": 35,
+                "max_mem": 196000,
+                "gpu": None,
+                "max_ngpus": 0,
+                "max_runtime": 86400,
+                "architecture": "x86_86",
+                "description": "Partition 1",
+                "simple": True,
+                "jupyter_environments": {
+                    "default": {
+                        "path": "/default/jupyter_env_path/bin/",
+                        "description": "default",
+                        "add_to_path": True,
+                    },
+                },
+            }
+        }
+        assert ref_partitions_info == slurm_data["partitions"]
+
+
+async def test_spawn_from_get_query(app):
+    """Test spawning through a GET query"""
+    with mock.patch.dict(app.users.settings, {"spawner_class": MOSSMockSimple}):
+        cookies = await app.login_user("jones")
+        r = await get_page("spawn?partition=partition_1&nprocs=4", app, cookies=cookies)
+
+        assert r.status_code == 200
+        assert "/hub/spawn-pending" in r.url
+
+
+async def test_spawn_from_post_request(app):
+    """Test spawning through a POST request"""
+    with mock.patch.dict(app.users.settings, {"spawner_class": MOSSMockSimple}):
+        cookies = await app.login_user("jones")
+        r = await post_request(
+            "spawn",
+            app,
+            cookies=cookies,
+            data={"partition": "partition_1", "nprocs": 4},
+        )
+
+        assert r.status_code == 200
+        assert "/hub/spawn-pending" in r.url

--- a/test/test_spawn_page.py
+++ b/test/test_spawn_page.py
@@ -13,9 +13,10 @@ class MOSSMockSimple(MOSlurmSpawnerMock):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
-        # Partition name, nnodes, ncores_per_node, ncores (allocated/idle/other/total), gpu, memory, timelimit
+        # Partition name, nnodes (allocated/idle/other/total), ncores_per_node,
+        # ncores (allocated/idle/other/total), gpu, memory, timelimit
         self.slurm_info_cmd = (
-            'echo "partition_1 48 35+ 38/1642/0/1680 (null) 196000+ 1-00:00:00"'
+            'echo "partition_1 2/46/0/48 35+ 38/1642/0/1680 (null) 196000+ 1-00:00:00"'
         )
 
         # Set partitions here so that validation is run
@@ -51,6 +52,7 @@ async def test_spawn_page(app):
 
         ref_partitions_info = {
             "partition_1": {
+                "nnodes_idle": 46,
                 "nnodes_total": 48,
                 "ncores_total": 1680,
                 "ncores_idle": 1642,

--- a/test/utils.py
+++ b/test/utils.py
@@ -1,0 +1,39 @@
+from jupyterhub.tests.utils import async_requests, public_host
+from jupyterhub.utils import url_path_join
+from traitlets import Unicode, default
+
+from jupyterhub_moss import MOSlurmSpawner
+
+
+def post_request(path, app, **kwargs):
+    """Send a POST request on the hub
+
+    Similar to jupyterhub.tests.utils.get_page
+    """
+    base_url = url_path_join(public_host(app), app.hub.base_url)
+    return async_requests.post(url_path_join(base_url, path), **kwargs)
+
+
+class MOSlurmSpawnerMock(MOSlurmSpawner):
+    """MOSlurmSpawner with some overrides to mock some features.
+
+    Adapted from jupyterhub.tests.mocking.MockSpawner and
+    batchspawner.tests.test_spawner.BatchDummy
+    """
+
+    exec_prefix = Unicode("")
+    batch_submit_cmd = Unicode("cat > /dev/null; sleep 1")
+    batch_query_cmd = Unicode("echo PENDING")
+    batch_cancel_cmd = Unicode("echo STOP")
+
+    req_homedir = Unicode(help="The home directory for the user")
+
+    @default("req_homedir")
+    def _default_req_homedir(self):
+        return f"/tmp/jupyterhub_moss_tests/{self.user.name}"
+
+    def user_env(self, env):
+        env["USER"] = self.user.name
+        env["HOME"] = self.req_homedir
+        env["SHELL"] = "/bin/bash"
+        return env


### PR DESCRIPTION
This PR includes PR #82.

This PR adds a few basic tests to check that the spawn page is generated and that spawning both through GET and POST requests work.
It reuses a fixture from jupyterhub and adapts mock-up from batchspawner and jupyterhub to achieve this.