### PR TITLE
Use pydantic and typing

### DIFF
--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -36,7 +36,7 @@ jobs:
         run: flake8 .
 
       - name: mypy 🧐
-        run: mypy .
+        run: mypy
 
       - name: check-manifest 📰
         run: check-manifest

--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -35,6 +35,9 @@ jobs:
       - name: flake8 ❄️
         run: flake8 .
 
+      - name: mypy 🧐
+        run: mypy .
+
       - name: check-manifest 📰
         run: check-manifest
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Set up Python 🐍
       uses: actions/setup-python@v2
       with:
-        python-version: 3.7
+        python-version: 3.10
 
     - name: Install dependencies ⚙️
       run: |

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.mypy_cache
 .project
 .pydevproject
 build/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,7 +35,7 @@ statically. The config is located in `pyproject.toml`. Type checking can be run
 using
 
 ```
-mypy .
+mypy
 ```
 
 ### Testing

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,6 +28,16 @@ manually using
 black .
 ```
 
+### Typing
+
+[mypy](https://mypy.readthedocs.io/en/stable) is used to check typing
+statically. The config is located in `pyproject.toml`. Type checking can be run
+using
+
+```
+mypy .
+```
+
 ### Testing
 
 [pytest](https://docs.pytest.org/en/latest/) is used to run the tests. The
@@ -44,7 +54,8 @@ Note: This is different from calling `pytest`, see
 
 The CI will check that the lint check passes, that all files are correctly
 formatted (using `black --check .`) and that tests passes. Before commiting, be
-sure to run `flake8`, `black` and `python -m pytest` to ensure CI passes.
+sure to run `flake8`, `black`, `mypy` and `python -m pytest` to ensure CI
+passes.
 
 ## Generate the spawn page locally
 

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ For a minimalistic working demo, check the
 - `gpu`: [Optional] A template string that will be used to request GPU resources
   through `--gres`. The template should therefore include a `{}` that will be
   replaced by the number of requested GPU **and** follow the format expected by
-  `--gres`. If no GPU is available for this partition, set to `None`. It is
+  `--gres`. If no GPU is available for this partition, set to `""`. It is
   retrieved from SLURM if not provided.
 - `max_ngpus`: [Optional] The maximum number of GPU that can be requested for
   this partition. The spawn page will use this to generate appropriate bounds

--- a/demo/jupyterhub_conf.py
+++ b/demo/jupyterhub_conf.py
@@ -7,7 +7,7 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")
 
 import jupyterhub_moss  # noqa
 
-c = get_config()  # noqa
+c = get_config()  # type: ignore[name-defined] # noqa
 
 # Select the MOSlurmSpawner backend
 jupyterhub_moss.set_config(c)

--- a/jupyterhub_moss/models.py
+++ b/jupyterhub_moss/models.py
@@ -152,6 +152,7 @@ class UserOptions(BaseModel):
 
     @classmethod
     def parse_formdata(cls, formdata: dict[str, list[str]]) -> UserOptions:
+        # Those keys should not come from the request, they are set later by the spawner
         excluded_keys = "gres", "prologue"
         fields = {
             k: v[0].strip() for k, v in formdata.items() if k not in excluded_keys

--- a/jupyterhub_moss/models.py
+++ b/jupyterhub_moss/models.py
@@ -22,7 +22,7 @@ def is_strictly_positive(v: Optional[int]) -> Optional[int]:
 
 def check_match_gpu(v: Optional[int], values: dict) -> Optional[int]:
     if v is not None and v > 0 and values.get("gpu") == "":
-        raise ValueError("Value must be 0 if gpu is ''")
+        return 0  # GPU explicitly disabled
     return v
 
 

--- a/jupyterhub_moss/models.py
+++ b/jupyterhub_moss/models.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import re
-from typing import Optional
+from typing import Dict, Optional
 
 from pydantic import BaseModel, Extra, validator
 
@@ -91,7 +91,7 @@ class PartitionConfig(BaseModel, allow_mutation=False, extra=Extra.forbid):
 
     architecture = ""
     description = ""
-    jupyter_environments: dict[str, JupyterEnvironment]
+    jupyter_environments: Dict[str, JupyterEnvironment]
     simple = True
 
 
@@ -122,7 +122,7 @@ class _PartitionTraits(PartitionConfig, allow_mutation=False, extra=Extra.forbid
 class PartitionsTrait(BaseModel, allow_mutation=False, extra=Extra.forbid):
     """Configuration passed as ``partitions`` trait"""
 
-    __root__: dict[str, _PartitionTraits]
+    __root__: Dict[str, _PartitionTraits]
 
     def dict(self, *args, **kwargs):
         return {k: v.dict(*args, **kwargs) for k, v in self.__root__.items()}

--- a/jupyterhub_moss/models.py
+++ b/jupyterhub_moss/models.py
@@ -1,0 +1,208 @@
+from __future__ import annotations
+
+import re
+from typing import Optional
+
+from pydantic import BaseModel, Extra, validator
+
+# validators
+
+
+def is_positive(v: Optional[int]) -> Optional[int]:
+    if v is not None and v < 0:
+        raise ValueError("Value must be positive")
+    return v
+
+
+def is_strictly_positive(v: Optional[int]) -> Optional[int]:
+    if v is not None and v <= 0:
+        raise ValueError("Value must be strictly positive")
+    return v
+
+
+def check_match_gpu(v: Optional[int], values: dict) -> Optional[int]:
+    if v is not None and v > 0 and values.get("gpu") == "":
+        raise ValueError("Value must be 0 if gpu is ''")
+    return v
+
+
+# models
+
+
+class PartitionResources(BaseModel, allow_mutation=False, extra=Extra.allow):
+    """SLURM partition required resources information
+
+    This information retrieved from SLURM is used to constraint user's selection.
+    Extra fields (e.g., as in :class:`PartitionAllResources`) can be used to display
+    information about available resources.
+    """
+
+    max_nprocs: int
+    max_mem: int
+    gpu: str
+    max_ngpus: int
+    max_runtime: int
+
+    # validators
+    _is_positive = validator("max_ngpus", allow_reuse=True)(is_positive)
+    _check_match_gpu = validator("max_ngpus", allow_reuse=True)(check_match_gpu)
+    _is_strictly_positive = validator(
+        "max_nprocs", "max_mem", "max_runtime", allow_reuse=True
+    )(is_strictly_positive)
+
+
+class PartitionAllResources(
+    PartitionResources, allow_mutation=False, extra=Extra.forbid
+):
+    """SLURM partition resources information
+
+    Extends resource constraints information with information
+    used to display available resources.
+    """
+
+    nnodes_total: int
+    nnodes_idle: int
+    ncores_total: int
+    ncores_idle: int
+
+    # validators
+    _is_positive = validator(
+        "nnodes_total", "nnodes_total", "ncores_total", "ncores_idle", allow_reuse=True
+    )(is_positive)
+
+
+class JupyterEnvironment(BaseModel, allow_mutation=False, extra=Extra.forbid):
+    """Single Jupyter environement description"""
+
+    add_to_path = True
+    description: str
+    path: str
+    prologue = ""
+
+    @validator("path", "description")
+    def check_not_empty(cls, v: str) -> str:
+        if not v:
+            raise ValueError("String must not be empty")
+        return v
+
+
+class PartitionConfig(BaseModel, allow_mutation=False, extra=Extra.forbid):
+    """Information about partition description and available environments"""
+
+    architecture = ""
+    description = ""
+    jupyter_environments: dict[str, JupyterEnvironment]
+    simple = True
+
+
+class PartitionInfo(
+    PartitionConfig, PartitionResources, allow_mutation=False, extra=Extra.allow
+):
+    """Complete information about a partition: config and resources"""
+
+    pass
+
+
+class _PartitionTraits(PartitionConfig, allow_mutation=False, extra=Extra.forbid):
+    """Configuration of a single partition passed as ``partitions`` traits"""
+
+    gpu: Optional[str] = None
+    max_ngpus: Optional[int] = None
+    max_nprocs: Optional[int] = None
+    max_runtime: Optional[int] = None
+
+    # validators
+    _is_positive = validator("max_ngpus", allow_reuse=True)(is_positive)
+    _check_match_gpu = validator("max_ngpus", allow_reuse=True)(check_match_gpu)
+    _is_strictly_positive = validator("max_nprocs", "max_runtime", allow_reuse=True)(
+        is_strictly_positive
+    )
+
+
+class PartitionsTrait(BaseModel, allow_mutation=False, extra=Extra.forbid):
+    """Configuration passed as ``partitions`` trait"""
+
+    __root__: dict[str, _PartitionTraits]
+
+    def dict(self, *args, **kwargs):
+        return {k: v.dict(*args, **kwargs) for k, v in self.__root__.items()}
+
+    def items(self):
+        return self.__root__.items()
+
+
+_MEM_REGEXP = re.compile("^[0-9]*([0-9]+[KMGT])?$")
+
+
+class FormOptions(BaseModel, allow_mutation=False):
+    """Options received through the form or GET request"""
+
+    partition: str
+    runtime = ""
+    nprocs = 1
+    memory = ""
+    reservation = ""
+    ngpus = 0
+    options = ""
+    output = "/dev/null"
+    environment_path = ""
+    default_url = ""
+    root_dir = ""
+
+    def __init__(self, mem: str = "", **kwargs):
+        # Align naming of form field with sbatch script
+        if "memory" not in kwargs:
+            kwargs["memory"] = mem
+        super().__init__(**kwargs)
+
+    # validators
+    _is_positive = validator("ngpus", allow_reuse=True)(is_positive)
+    _is_strictly_positive = validator("nprocs", allow_reuse=True)(is_strictly_positive)
+
+    @validator(
+        "partition",
+        "runtime",
+        "memory",
+        "reservation",
+        "options",
+        "output",
+        "environment_path",
+        "default_url",
+        "root_dir",
+    )
+    def has_no_newline(cls, v: str) -> str:
+        if "\n" in v:
+            raise ValueError("Must not contain newline")
+        return v
+
+    @validator("default_url")
+    def is_absolute_path(cls, v: str) -> str:
+        if v and not v.startswith("/"):
+            raise ValueError("Must start with /")
+        return v
+
+    @validator("runtime")
+    def check_timelimit(cls, v: str) -> str:
+        from .utils import parse_timelimit  # avoid circular imports
+
+        if v:
+            parse_timelimit(v)  # Raises exception if malformed
+        return v
+
+    @validator("memory")
+    def check_memory(cls, v: str) -> str:
+        if v and _MEM_REGEXP.match(v) is None:
+            raise ValueError("Error in memory syntax")
+        return v
+
+    @validator("output")
+    def normalize_output(cls, v: str) -> str:
+        """Convert output option from boolean to file pattern"""
+        return "slurm-%j.out" if v == "true" else "/dev/null"
+
+
+class UserOptions(FormOptions, allow_mutation=True):
+    """Options passed as `Spawner.user_options`"""
+
+    gres = ""
+    prologue = ""

--- a/jupyterhub_moss/models.py
+++ b/jupyterhub_moss/models.py
@@ -7,6 +7,7 @@ from pydantic import (
     BaseModel,
     ConstrainedStr,
     Extra,
+    Field,
     NonNegativeInt,
     PositiveInt,
     validator,
@@ -68,7 +69,8 @@ class JupyterEnvironment(BaseModel, allow_mutation=False, extra=Extra.forbid):
     add_to_path = True
     description: NonEmptyStr
     path: NonEmptyStr
-    prologue = ""
+    # Strip prologue from export: useless and parsing issues in javascript
+    prologue: str = Field("", exclude=True)
 
 
 class PartitionConfig(BaseModel, allow_mutation=False, extra=Extra.forbid):

--- a/jupyterhub_moss/spawner.py
+++ b/jupyterhub_moss/spawner.py
@@ -365,7 +365,7 @@ class MOSlurmSpawner(SlurmSpawner):
         if "\n" in options["root_dir"]:
             raise AssertionError("Error in root_dir")
 
-    def __update_options(
+    def __create_user_options(
         self, form_options: FormOptions, partition_info: PartitionInfo
     ) -> UserOptions:
         """Extends/Modify options to be used for the spawn."""
@@ -406,7 +406,6 @@ class MOSlurmSpawner(SlurmSpawner):
         """Parse the form and add options to the SLURM job script"""
         form_options = self.__convert_formdata(formdata)
 
-        assert "partition" in form_options, "Partition information is missing"
         assert (
             form_options["partition"] in self.partitions
         ), "Partition is not supported"
@@ -415,7 +414,7 @@ class MOSlurmSpawner(SlurmSpawner):
 
         self.__validate_options(form_options, partition_info)
 
-        user_options = self.__update_options(form_options, partition_info)
+        user_options = self.__create_user_options(form_options, partition_info)
         return user_options
 
     def __update_spawn_commands(self, cmd_path: str) -> None:
@@ -442,8 +441,7 @@ class MOSlurmSpawner(SlurmSpawner):
         self.default_url = self.user_options["default_url"]
         self.log.info(f"Used default URL: {self.default_url}")
 
-        if self.user_options["root_dir"]:
-            self.notebook_dir = self.user_options["root_dir"]
+        self.notebook_dir = self.user_options["root_dir"]
 
         environment_path = self.user_options["environment_path"]
         self.log.info(f"Used environment: {environment_path}")

--- a/jupyterhub_moss/spawner.py
+++ b/jupyterhub_moss/spawner.py
@@ -259,6 +259,7 @@ class MOSlurmSpawner(SlurmSpawner):
     @staticmethod
     async def create_options_form(spawner: MOSlurmSpawner) -> str:
         """Create a form for the user to choose the configuration for the SLURM job"""
+        # Cast to allow stripping sent information
         partitions_info = cast(dict, await spawner._get_partitions_info())
 
         simple_partitions = [
@@ -366,6 +367,8 @@ class MOSlurmSpawner(SlurmSpawner):
         self, form_options: FormOptions, partition_info: PartitionInfo
     ) -> UserOptions:
         """Extends/Modify options to be used for the spawn."""
+        # Cast to initialize UserOptions from FormOptions
+        # Should be solved by https://github.com/python/mypy/pull/13353
         options = cast(UserOptions, dict(gres="", prologue="", **form_options))
 
         # Specific handling of exclusive flag

--- a/jupyterhub_moss/spawner.py
+++ b/jupyterhub_moss/spawner.py
@@ -7,7 +7,7 @@ import json
 import os.path
 import re
 from copy import deepcopy
-from typing import Callable, cast
+from typing import Callable, Dict, cast
 
 import traitlets
 from batchspawner import SlurmSpawner, format_template
@@ -256,7 +256,7 @@ class MOSlurmSpawner(SlurmSpawner):
                     )
 
         # Ensure returning a dict that can be modified by the callers
-        return cast(dict[str, PartitionInfo], deepcopy(partitions_info))
+        return cast(Dict[str, PartitionInfo], deepcopy(partitions_info))
 
     @staticmethod
     async def create_options_form(spawner: MOSlurmSpawner) -> str:

--- a/jupyterhub_moss/spawner.py
+++ b/jupyterhub_moss/spawner.py
@@ -73,7 +73,9 @@ class MOSlurmSpawner(SlurmSpawner):
 
     @traitlets.validate("partitions")
     def _validate_partitions(self, proposal: dict) -> dict[str, dict]:
-        return PartitionsTrait.parse_obj(proposal["value"]).dict()
+        partitions = proposal["value"]
+        PartitionsTrait.parse_obj(partitions)  # Validation
+        return partitions
 
     slurm_info_cmd = traitlets.Unicode(
         # Get number of nodes/state, cores/node, cores/state, gpus, total memory for all partitions
@@ -247,18 +249,7 @@ class MOSlurmSpawner(SlurmSpawner):
             raise RuntimeError("No 'simple' partition defined: No default partition")
         default_partition = simple_partitions[0]
 
-        # Strip prologue from partitions_info:
-        # it is not useful and can cause some parsing issues
-        partitions_dict = {
-            name: info.dict(
-                exclude={
-                    "jupyter_environments": {
-                        env_name: {"prologue"} for env_name in info.jupyter_environments
-                    }
-                }
-            )
-            for name, info in partitions_info.items()
-        }
+        partitions_dict = {k: v.dict() for k, v in partitions_info.items()}
 
         # Prepare json info
         jsondata = json.dumps(

--- a/jupyterhub_moss/spawner.py
+++ b/jupyterhub_moss/spawner.py
@@ -252,13 +252,18 @@ class MOSlurmSpawner(SlurmSpawner):
             raise RuntimeError("No 'simple' partition defined: No default partition")
         default_partition = simple_partitions[0]
 
-        partitions_dict = {k: v.dict() for k, v in partitions_info.items()}
-
         # Strip prologue from partitions_info:
         # it is not useful and can cause some parsing issues
-        for partition_info in partitions_dict.values():
-            for env_info in partition_info["jupyter_environments"].values():
-                env_info.pop("prologue", None)
+        partitions_dict = {
+            name: info.dict(
+                exclude={
+                    "jupyter_environments": {
+                        env_name: {"prologue"} for env_name in info.jupyter_environments
+                    }
+                }
+            )
+            for name, info in partitions_info.items()
+        }
 
         # Prepare json info
         jsondata = json.dumps(

--- a/jupyterhub_moss/spawner.py
+++ b/jupyterhub_moss/spawner.py
@@ -31,14 +31,8 @@ RESOURCES_HASH = {
 with open(local_path("batch_script.sh")) as f:
     BATCH_SCRIPT = f.read()
 
-try:
-    BATCHSPAWNER_VERSION = importlib.metadata.version("batchspawner")
-except importlib.metadata.PackageNotFoundError:
-    BATCHSPAWNER_VERSION = ""
-try:
-    JUPYTERHUB_VERSION = importlib.metadata.version("jupyterhub")
-except importlib.metadata.PackageNotFoundError:
-    JUPYTERHUB_VERSION = ""
+BATCHSPAWNER_VERSION = importlib.metadata.version("batchspawner")
+JUPYTERHUB_VERSION = importlib.metadata.version("jupyterhub")
 
 
 class MOSlurmSpawner(SlurmSpawner):

--- a/jupyterhub_moss/spawner.py
+++ b/jupyterhub_moss/spawner.py
@@ -58,7 +58,7 @@ class MOSlurmSpawner(SlurmSpawner):
             per_key_traits={
                 "description": traitlets.Unicode(),
                 "architecture": traitlets.Unicode(),
-                "gpu": traitlets.Unicode(allow_none=True, default_value=None),
+                "gpu": traitlets.Unicode(allow_none=True),
                 "simple": traitlets.Bool(),
                 "jupyter_environments": traitlets.Dict(
                     key_trait=traitlets.Unicode(),
@@ -87,6 +87,8 @@ class MOSlurmSpawner(SlurmSpawner):
         # Set add_to_path if missing in jupyter_environments
         partitions = deepcopy(proposal["value"])
         for partition in partitions.values():
+            if "gpu" in partition and partition["gpu"] is None:
+                partition["gpu"] = ""  # Convert None to ""
             for env in partition["jupyter_environments"].values():
                 env.setdefault("add_to_path", True)
                 env.setdefault("prologue", "")

--- a/jupyterhub_moss/spawner.py
+++ b/jupyterhub_moss/spawner.py
@@ -10,6 +10,7 @@ from typing import Callable
 import traitlets
 from batchspawner import SlurmSpawner, format_template
 from jinja2 import ChoiceLoader, Environment, FileSystemLoader, PrefixLoader
+from pydantic import ValidationError
 
 from .models import (
     PartitionAllResources,
@@ -162,7 +163,7 @@ class MOSlurmSpawner(SlurmSpawner):
                     max_ngpus=gpus_total,
                     max_runtime=max_runtime.total_seconds(),
                 )
-            except ValueError as err:
+            except ValidationError as err:
                 self.log.error("Error parsing output of slurm_info_cmd: %s", err)
                 raise
 

--- a/jupyterhub_moss/templates/option_form.html
+++ b/jupyterhub_moss/templates/option_form.html
@@ -256,8 +256,8 @@ window.SLURM_DATA = JSON.parse('{{ jsondata }}');
           </div>
           <div>
             &#9888; Required packages in custom environments:<br>
-            <a href="https://pypi.org/project/batchspawner/">batchspawner</a>{% if batchspawner_version %}~={{batchspawner_version}}{% endif %} and
-            <a href="https://pypi.org/project/jupyterhub/">jupyterhub</a>{% if jupyterhub_version %}~={{jupyterhub_version}}{% endif %}.
+            <a href="https://pypi.org/project/batchspawner/">batchspawner</a>~={{batchspawner_version}} and
+            <a href="https://pypi.org/project/jupyterhub/">jupyterhub</a>~={{jupyterhub_version}}.
           </div>
         </div>
       </div>

--- a/jupyterhub_moss/utils.py
+++ b/jupyterhub_moss/utils.py
@@ -4,64 +4,9 @@ import datetime
 import hashlib
 import os.path
 import re
-from typing import Any, Callable, Iterable, Optional, TypedDict
+from typing import Any, Callable, Iterable, Optional
 
-
-class FormOptions(TypedDict):
-    """Options received through the form or GET request"""
-
-    partition: str
-    runtime: str
-    nprocs: int
-    memory: str
-    reservation: str
-    ngpus: int
-    options: str
-    output: str
-    environment_path: str
-    default_url: str
-    root_dir: str
-
-
-class UserOptions(FormOptions):
-    """Options passed as `Spawner.user_options`"""
-
-    gres: str
-    prologue: str
-
-
-class PartitionResources(TypedDict):
-    """SLURM partition resources information"""
-
-    # display resource counts
-    nnodes_total: int
-    nnodes_idle: int
-    ncores_total: int
-    ncores_idle: int
-    # required resource counts
-    max_nprocs: int
-    max_mem: int
-    gpu: str
-    max_ngpus: int
-    max_runtime: int
-
-
-class JupyterEnvironment(TypedDict):
-    """Single Jupyter environement description"""
-
-    add_to_path: bool
-    description: str
-    path: str
-    prologue: str
-
-
-class PartitionInfo(PartitionResources):
-    """Complete information about a partition"""
-
-    description: str
-    architecture: str
-    simple: bool
-    jupyter_environments: dict[str, JupyterEnvironment]
+from .models import JupyterEnvironment
 
 
 def local_path(path: str) -> str:
@@ -110,11 +55,11 @@ def create_prologue(
     prologue = default_prologue
 
     corresponding_default_env = find(
-        lambda env: env["path"] == environment_path,
+        lambda env: env.path == environment_path,
         partition_environments,
     )
     if corresponding_default_env is not None:
-        prologue += f"\n{corresponding_default_env['prologue']}"
+        prologue += f"\n{corresponding_default_env.prologue}"
 
     # Singularity images are never added to PATH
     if environment_path.endswith(".sif"):
@@ -122,6 +67,6 @@ def create_prologue(
 
     # Custom envs are always added to PATH
     # Defaults envs only if add_to_path is True
-    if corresponding_default_env is None or corresponding_default_env["add_to_path"]:
+    if corresponding_default_env is None or corresponding_default_env.add_to_path:
         prologue += f"\nexport PATH={environment_path}:$PATH"
     return prologue

--- a/jupyterhub_moss/utils.py
+++ b/jupyterhub_moss/utils.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import datetime
 import hashlib
 import os.path

--- a/jupyterhub_moss/utils.py
+++ b/jupyterhub_moss/utils.py
@@ -2,7 +2,64 @@ import datetime
 import hashlib
 import os.path
 import re
-from typing import Any, Callable, Iterable, Optional
+from typing import Any, Callable, Iterable, Optional, TypedDict
+
+
+class FormOptions(TypedDict):
+    """Options received through the form or GET request"""
+
+    partition: str
+    runtime: str
+    nprocs: int
+    memory: str
+    reservation: str
+    ngpus: int
+    options: str
+    output: str
+    environment_path: str
+    default_url: str
+    root_dir: str
+
+
+class UserOptions(FormOptions):
+    """Options passed as `Spawner.user_options`"""
+
+    gres: str
+    prologue: str
+
+
+class PartitionResources(TypedDict):
+    """SLURM partition resources information"""
+
+    # display resource counts
+    nnodes_total: int
+    nnodes_idle: int
+    ncores_total: int
+    ncores_idle: int
+    # required resource counts
+    max_nprocs: int
+    max_mem: int
+    gpu: str
+    max_ngpus: int
+    max_runtime: int
+
+
+class JupyterEnvironment(TypedDict):
+    """Single Jupyter environement description"""
+
+    add_to_path: bool
+    description: str
+    path: str
+    prologue: str
+
+
+class PartitionInfo(PartitionResources):
+    """Complete information about a partition"""
+
+    description: str
+    architecture: str
+    simple: bool
+    jupyter_environments: dict[str, JupyterEnvironment]
 
 
 def local_path(path: str) -> str:
@@ -45,7 +102,7 @@ def parse_timelimit(timelimit: str) -> datetime.timedelta:
 def create_prologue(
     default_prologue: str,
     environment_path: str,
-    partition_environments: Iterable[dict],
+    partition_environments: Iterable[JupyterEnvironment],
 ) -> str:
     """Create prologue commands"""
     prologue = default_prologue

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ testpaths = [
 
 [tool.mypy]
 python_version = "3.8"
+plugins = "pydantic.mypy"
 files = [
   "jupyterhub_moss",
   "test",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,9 +14,11 @@ testpaths = [
   "test",
 ]
 
-
 [[tool.mypy.overrides]]
 module = [
     "batchspawner",
+    "jupyterhub.tests.utils",
+    "jupyterhub.utils",
+    "setuptools",
 ]
 ignore_missing_imports = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,3 +13,10 @@ asyncio_mode = "auto"
 testpaths = [
   "test",
 ]
+
+
+[[tool.mypy.overrides]]
+module = [
+    "batchspawner",
+]
+ignore_missing_imports = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,11 +14,17 @@ testpaths = [
   "test",
 ]
 
+[tool.mypy]
+python_version = "3.8"
+files = [
+  "jupyterhub_moss",
+  "test",
+]
+
 [[tool.mypy.overrides]]
 module = [
     "batchspawner",
     "jupyterhub.tests.utils",
     "jupyterhub.utils",
-    "setuptools",
 ]
 ignore_missing_imports = true

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,6 +36,7 @@ dev =
     check-manifest
     flake8
     jupyter_server
+    mypy
     pytest
     pytest-asyncio
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,6 +26,7 @@ install_requires =
     batchspawner>=1.0
     jinja2
     jupyterhub
+    pydantic
     traitlets
 
 [options.extras_require]

--- a/test/test_spawn_page.py
+++ b/test/test_spawn_page.py
@@ -58,7 +58,7 @@ async def test_spawn_page(app):
                 "ncores_idle": 1642,
                 "max_nprocs": 35,
                 "max_mem": 196000,
-                "gpu": None,
+                "gpu": "",
                 "max_ngpus": 0,
                 "max_runtime": 86400,
                 "architecture": "x86_86",


### PR DESCRIPTION
~~This PR builds over PR #88~~

It sets-up type checking with mypy.

It uses `pydantic.BaseModel` to:
- validate `MOSlurmSpawner.partitions` traits dict
- convert and validate options received from the GET|POST request.

It allows to move syntax checks into the model's validators.

closes #37
closes #49
closes #78 