### PR TITLE
Update handling of `default_url` in option form

### DIFF
--- a/jupyterhub_moss/form/option_form.js
+++ b/jupyterhub_moss/form/option_form.js
@@ -248,6 +248,7 @@ function resetSpawnForm() {
   document.getElementById('spawn_form').reset();
   restoreCustomEnvironmentsFromLocalStorage();
   setSimplePartition(window.SLURM_DATA.default_partition);
+  updateDefaultUrl();
 }
 
 function setVisible(element, visible) {
@@ -332,6 +333,13 @@ function updateMemValue() {
 
   // Pass empty field and 0 as is, append G for others
   memHiddenElem.value = value && value !== '0' ? `${value}G` : value;
+}
+
+function updateDefaultUrl() {
+  const defaultUrlCheckboxElem = document.getElementById('default_url_input');
+  const defaultUrlHiddenElem = document.getElementById('default_url');
+
+  defaultUrlHiddenElem.value = defaultUrlCheckboxElem.checked ? '/lab' : '/tree';
 }
 
 function updatePartitionLimits() {
@@ -470,7 +478,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const nprocsElem = document.getElementById('nprocs');
   const ngpusElem = document.getElementById('ngpus');
   const runtimeElem = document.getElementById('runtime');
-  const default_url = document.getElementById('default_url');
+  const defaultUrlCheckboxElem = document.getElementById('default_url_input');
   const environmentAddRadio = document.getElementById('environment_add_radio');
   const environmentAddName = document.getElementById('environment_add_name');
   const environmentAddPath = document.getElementById('environment_add_path');
@@ -505,8 +513,11 @@ document.addEventListener('DOMContentLoaded', () => {
   document
     .getElementById('jupyterlab_simple')
     .addEventListener('change', (e) => {
-      default_url.checked = e.target.checked;
+      defaultUrlCheckboxElem.checked = e.target.checked;
+      updateDefaultUrl();
     });
+  // Update default_url hidden input
+  defaultUrlCheckboxElem.addEventListener('change', updateDefaultUrl)
   // Runtime
   document.getElementById('runtime_simple').addEventListener('change', (e) => {
     runtimeElem.value = `${e.target.value}:00:00`;

--- a/jupyterhub_moss/templates/option_form.html
+++ b/jupyterhub_moss/templates/option_form.html
@@ -212,12 +212,16 @@ window.SLURM_DATA = JSON.parse('{{ jsondata }}');
       placeholder="hh:mm:ss"
       pattern="[0-9]+:[0-5][0-9]:[0-5][0-9]"
     />
-    <label for="default_url">Launch JupyterLab:</label>
+    <label for="default_url_input">Launch JupyterLab:</label>
     <input
-      type="checkbox"
+      type="hidden"
       id="default_url"
       name="default_url"
       value="/lab"
+    />
+    <input
+      type="checkbox"
+      id="default_url_input"
       checked
     />
     <label>Jupyter environment:</label>


### PR DESCRIPTION
This PR sets `default_url` to either `/lab` or `/tree` (for classic notebook UI) instead of `/lab` or not set (which used to default to classic notebook).

According to [migrate_to_notebook7 doc](https://jupyter-notebook.readthedocs.io/en/latest/migrate_to_notebook7.html), it should work with in a variety of past/present/future? cases.