### PR TITLE
Fix stored value for `default_url`

### DIFF
--- a/jupyterhub_moss/form/option_form.js
+++ b/jupyterhub_moss/form/option_form.js
@@ -336,8 +336,8 @@ function updateMemValue() {
 }
 
 function updateDefaultUrl() {
-  const defaultUrlCheckboxElem = document.getElementById('default_url_input');
-  const defaultUrlHiddenElem = document.getElementById('default_url');
+  const defaultUrlCheckboxElem = document.getElementById('default_url');
+  const defaultUrlHiddenElem = document.getElementById('default_url_hidden_input');
 
   defaultUrlHiddenElem.value = defaultUrlCheckboxElem.checked ? '/lab' : '/tree';
 }
@@ -478,7 +478,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const nprocsElem = document.getElementById('nprocs');
   const ngpusElem = document.getElementById('ngpus');
   const runtimeElem = document.getElementById('runtime');
-  const defaultUrlCheckboxElem = document.getElementById('default_url_input');
+  const defaultUrlCheckboxElem = document.getElementById('default_url');
   const environmentAddRadio = document.getElementById('environment_add_radio');
   const environmentAddName = document.getElementById('environment_add_name');
   const environmentAddPath = document.getElementById('environment_add_path');

--- a/jupyterhub_moss/templates/option_form.html
+++ b/jupyterhub_moss/templates/option_form.html
@@ -212,16 +212,16 @@ window.SLURM_DATA = JSON.parse('{{ jsondata }}');
       placeholder="hh:mm:ss"
       pattern="[0-9]+:[0-5][0-9]:[0-5][0-9]"
     />
-    <label for="default_url_input">Launch JupyterLab:</label>
+    <label for="default_url">Launch JupyterLab:</label>
     <input
       type="hidden"
-      id="default_url"
+      id="default_url_hidden_input"
       name="default_url"
       value="/lab"
     />
     <input
       type="checkbox"
-      id="default_url_input"
+      id="default_url"
       checked
     />
     <label>Jupyter environment:</label>


### PR DESCRIPTION
#94 introduced an issue regarding what is stored in local storage: It used to be `true`/`false` for `default_url` and with #94 it became `/lab`/`/tree` and was not recovered well on reload since a boolean was expected....

This PR fixes by setting the `id` of the JLab checkbox back to `default_url`.