### PR TITLE
Add support for environment modules

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Set up Python 🐍
       uses: actions/setup-python@v2
       with:
-        python-version: 3.10
+        python-version: '3.10'
 
     - name: Install dependencies ⚙️
       run: |

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ c.MOSlurmSpawner.partitions = {
             "default": {                   # Jupyter environment identifier, at least "path" or "modules" is mandatory
                 "description": "Default",  # Text displayed for this environment select option
                 "path": "/env/path/bin/",  # Path to Python environment bin/ used to start Jupyter server on the Slurm nodes
-                "modules": "",             # Comma separated list of environment modules to load before starting Jupyter server
+                "modules": "",             # Space separated list of environment modules to load before starting Jupyter server
                 "add_to_path": True,       # Toggle adding the environment to shell PATH (optional, default: True)
                 "prologue": "",            # Shell commands to execute before starting the Jupyter server (optional, default: "")
             },
@@ -142,7 +142,7 @@ For a minimalistic working demo, check the
     Slurm nodes. **jupyterhub_moss** needs that a virtual (or conda) environment
     is used to start Jupyter. This path can be changed according to the
     partitions.
-  - `modules`: Comma separated list of environment modules to load before
+  - `modules`: Space separated list of environment modules to load before
     starting the Jupyter server. Environment modules will be loaded with the
     `module` command.
   - `add_to_path`: Whether or not to prepend the environment `path` to shell

--- a/README.md
+++ b/README.md
@@ -55,9 +55,10 @@ c.MOSlurmSpawner.partitions = {
         "max_runtime": 12*3600,            # Maximum time limit in seconds (Must be at least 1hour)
         "simple": True,                    # True to show in Simple tab
         "jupyter_environments": {
-            "default": {                   # Jupyter environment internal identifier
-                "path": "/env/path/bin/",  # Path to Python environment bin/ used to start jupyter on the Slurm nodes
+            "default": {                   # Jupyter environment identifier, at least "path" or "modules" is mandatory
                 "description": "Default",  # Text displayed for this environment select option
+                "path": "/env/path/bin/",  # Path to Python environment bin/ used to start Jupyter server on the Slurm nodes
+                "modules": "",             # Comma separated list of environment modules to load before starting Jupyter server
                 "add_to_path": True,       # Toggle adding the environment to shell PATH (optional, default: True)
                 "prologue": "",            # Shell commands to execute before starting the Jupyter server (optional, default: "")
             },
@@ -73,8 +74,9 @@ c.MOSlurmSpawner.partitions = {
         "simple": True,
         "jupyter_environments": {
             "default": {
-                "path": "/path/to/jupyter/env/for/partition_2/bin/",
                 "description": "Default",
+                "path": "",
+                "modules": "JupyterLab/3.6.0",
                 "add_to_path": True,
                 "prologue": "echo 'Starting default environment'",
             },
@@ -90,8 +92,9 @@ c.MOSlurmSpawner.partitions = {
         "simple": False,
         "jupyter_environments": {
             "default": {
-                "path": "/path/to/jupyter/env/for/partition_3/bin/",
                 "description": "Partition 3 default",
+                "path": "/path/to/jupyter/env/for/partition_3/bin/",
+                "modules": "JupyterLab/3.6.0",
                 "add_to_path": True,
                 "prologue": "echo 'Starting default environment'",
         },
@@ -131,13 +134,17 @@ For a minimalistic working demo, check the
   where almost all Slurm job settings can be set. Some partitions can be hidden
   from the _Simple_ tab with setting `simple` to `False`.
 - `jupyter_environments`: Mapping of identifer name to information about Python
-  environment used to run Jupyter on the Slurm nodes. This information is a
-  mapping containing:
+  environment used to run Jupyter on the Slurm nodes. Either `path` or
+  `modules` (or both) should be defined. This information is a mapping
+  containing:
+  - `description`: Text used for display in the selection options.
   - `path`: The path to a Python environment bin/ used to start jupyter on the
     Slurm nodes. **jupyterhub_moss** needs that a virtual (or conda) environment
     is used to start Jupyter. This path can be changed according to the
     partitions.
-  - `description`: Text used for display in the selection options.
+  - `modules`: Comma separated list of environment modules to load before
+    starting the Jupyter server. Environment modules will be loaded with the
+    `module` command.
   - `add_to_path`: Whether or not to prepend the environment `path` to shell
     `PATH`.
   - `prologue`: Shell commands to execute on the Slurm node before starting the

--- a/demo/jupyterhub_conf.py
+++ b/demo/jupyterhub_conf.py
@@ -21,20 +21,20 @@ c.MOSlurmSpawner.partitions = {
         "simple": True,
         "jupyter_environments": {
             "default": {
-                "path": "/default/jupyter_env_path/bin/",
                 "description": "Operating system (default)",
+                "path": "/default/jupyter_env_path/bin/",
                 "add_to_path": False,
                 "prologue": 'echo "Starting default env."\n',
             },
-            "new-x86": {
-                "path": "/new-x86/jupyter_env_path/bin/",
+            "Python 3.11": {
                 "description": "New environment x86 (latest)",
-                "add_to_path": True,
+                "modules": "Python/3.11 JupyterLab/3.6.0",
+                "add_to_path": False,
                 "prologue": "echo 'Starting new-x86 env.'",
             },
             "latest": {
-                "path": "/latest/jupyter_env_path/bin/",
                 "description": "Operating system (latest)",
+                "path": "/latest/jupyter_env_path/bin/",
                 "prologue": "echo 'Starting latest env.'",
             },
         },
@@ -45,16 +45,16 @@ c.MOSlurmSpawner.partitions = {
         "simple": True,
         "jupyter_environments": {
             "default": {
-                "path": "/path/to/jupyter/env/for/partition_2/bin/",
                 "description": "Current environment (default)",
+                "path": "/path/to/jupyter/env/for/partition_2/bin/",
             },
             "latest": {
-                "path": "/latest/path/to/jupyter/env/for/partition_2/bin/",
                 "description": "Current environment (latest)",
+                "path": "/latest/path/to/jupyter/env/for/partition_2/bin/",
             },
-            "new-ppx64le": {
-                "path": "/new-ppc64le/jupyter_env_path/bin/",
+            "Python 3.11": {
                 "description": "New environment ppc64le (latest)",
+                "modules": "Python/3.11 JupyterLab/3.6.0",
             },
         },
     },
@@ -64,12 +64,12 @@ c.MOSlurmSpawner.partitions = {
         "simple": False,
         "jupyter_environments": {
             "default": {
-                "path": "/path/to/jupyter/env/for/partition_3/bin/",
                 "description": "Operating system (default)",
+                "path": "/path/to/jupyter/env/for/partition_3/bin/",
             },
             "new-x86": {
-                "path": "/new-x86/jupyter_env_path/bin/",
                 "description": "New environment x86 (latest)",
+                "path": "/new-x86/jupyter_env_path/bin/",
             },
         },
     },

--- a/jupyterhub_moss/form/option_form.css
+++ b/jupyterhub_moss/form/option_form.css
@@ -58,7 +58,7 @@
 #environment_simple {
   text-overflow: ellipsis;
   max-width: 100%;
-  padding: 1.0rem;
+  padding: 0.5rem 1rem;
   margin-top: -0.5rem;
   font-weight: 700;
 }

--- a/jupyterhub_moss/form/option_form.css
+++ b/jupyterhub_moss/form/option_form.css
@@ -157,6 +157,7 @@
   flex-flow: column nowrap;
   justify-content: flex-start;
   width: 100%;
+  gap: 0.5rem;
 }
 
 .environment-add-div > * {

--- a/jupyterhub_moss/form/option_form.css
+++ b/jupyterhub_moss/form/option_form.css
@@ -154,7 +154,7 @@
 
 .environment-add-div {
   display: flex;
-  flex-flow: row wrap;
+  flex-flow: column nowrap;
   justify-content: flex-start;
   width: 100%;
 }

--- a/jupyterhub_moss/form/option_form.css
+++ b/jupyterhub_moss/form/option_form.css
@@ -43,7 +43,7 @@
 }
 
 .subheading {
-  padding-top: 15px;
+  padding-top: 1em;
   text-align: center;
 }
 
@@ -57,7 +57,13 @@
 
 #environment_simple {
   text-overflow: ellipsis;
-  max-width: 20em;
+  max-width: 100%;
+  font-size: 1.2em;
+  padding: 1.5ex 1em 1ex 1em;
+}
+
+#runtime_simple {
+  padding: 1.0ex 0.5em 0.5ex 0.5em;
 }
 
 .form-container {

--- a/jupyterhub_moss/form/option_form.css
+++ b/jupyterhub_moss/form/option_form.css
@@ -145,7 +145,8 @@
 
 .environment-add-div {
   display: flex;
-  align-items: flex-start;
+  flex-flow: row wrap;
+  justify-content: flex-start;
   width: 100%;
 }
 
@@ -153,8 +154,8 @@
   margin-left: 0.3rem;
 }
 
-#environment_add_path {
-  flex: 1;
+.environment-add-div > input {
+  flex: 4 1 auto;
 }
 
 #environment_add_button {

--- a/jupyterhub_moss/form/option_form.css
+++ b/jupyterhub_moss/form/option_form.css
@@ -58,13 +58,13 @@
 #environment_simple {
   text-overflow: ellipsis;
   max-width: 100%;
-  padding: 0.5rem 1rem 0.5rem 1rem;
+  padding: 1.0rem;
   margin-top: -0.5rem;
   font-weight: 700;
 }
 
 #runtime_simple {
-  padding: 0.5rem 1rem 0.5rem 1rem;
+  padding: 0.5rem 1.0rem;
   margin-top: -0.5rem;
   font-weight: 700;
 }
@@ -73,7 +73,7 @@
   padding: 0.3em;
   display: grid;
   grid-template-columns: auto auto;
-  grid-gap: 0.5rem;
+  grid-gap: 1.0rem;
   justify-content: center;
   align-items: center;
   justify-items: stretch;

--- a/jupyterhub_moss/form/option_form.css
+++ b/jupyterhub_moss/form/option_form.css
@@ -58,12 +58,15 @@
 #environment_simple {
   text-overflow: ellipsis;
   max-width: 100%;
-  font-size: 1.2em;
-  padding: 1.5ex 1em 1ex 1em;
+  padding: 0.5rem 1rem 0.5rem 1rem;
+  margin-top: -0.5rem;
+  font-weight: 700;
 }
 
 #runtime_simple {
-  padding: 1.0ex 0.5em 0.5ex 0.5em;
+  padding: 0.5rem 1rem 0.5rem 1rem;
+  margin-top: -0.5rem;
+  font-weight: 700;
 }
 
 .form-container {

--- a/jupyterhub_moss/form/option_form.js
+++ b/jupyterhub_moss/form/option_form.js
@@ -211,7 +211,7 @@ function restoreCustomEnvironmentsFromLocalStorage() {
   }
 
   for (const key in config) {
-    addCustomEnvironment(key, config[key].description, config[key].path, config[key].modules, false);
+    addCustomEnvironment(key, config[key].description, config[key].path || "", config[key].modules || "", false);
   }
 }
 

--- a/jupyterhub_moss/form/option_form.js
+++ b/jupyterhub_moss/form/option_form.js
@@ -12,7 +12,7 @@ function createEnvironmentDiv(key, description, path, modules, checked = false) 
   div.classList.add('environment-div');
 
   const radio_id = `environment_radio_${key}`;
-  const title = `Environment Name: ${description}`;
+  const title = [path ? `Path: ${path}` : "", modules ? `Modules: ${modules}` : ""].filter(v => v).join("\n");
 
   // Store definitions in hidden inputs
   const path_input = document.createElement('input');

--- a/jupyterhub_moss/models.py
+++ b/jupyterhub_moss/models.py
@@ -67,13 +67,13 @@ class JupyterEnvironment(BaseModel, allow_mutation=False, extra=Extra.forbid):
 
     add_to_path = True
     description: NonEmptyStr
-    path: Optional[str] = ""
-    modules: Optional[str] = ""
-    prologue: Optional[str] = ""
+    path = ""
+    modules = ""
+    prologue = ""
 
     # validators
     @validator("modules")
-    def check_path_or_mods(cls, v: Optional[str], values: dict) -> Optional[str]:
+    def check_path_or_mods(cls, v: str, values: dict) -> str:
         if not v and not values.get("path"):
             raise ValueError("Jupyter environment path or modules is required")
         return v

--- a/jupyterhub_moss/models.py
+++ b/jupyterhub_moss/models.py
@@ -178,7 +178,9 @@ class UserOptions(BaseModel):
         "reservation",
         "options",
         "output",
+        "environment_id",
         "environment_path",
+        "environment_modules",
         "default_url",
         "root_dir",
     )

--- a/jupyterhub_moss/models.py
+++ b/jupyterhub_moss/models.py
@@ -75,7 +75,7 @@ class JupyterEnvironment(BaseModel, allow_mutation=False, extra=Extra.forbid):
     @validator("modules")
     def check_path_or_mods(cls, v: Optional[str], values: dict) -> Optional[str]:
         if not v and not values.get("path"):
-            raise ValueError(f"Jupyter environment path or modules is required")
+            raise ValueError("Jupyter environment path or modules is required")
         return v
 
 

--- a/jupyterhub_moss/models.py
+++ b/jupyterhub_moss/models.py
@@ -67,8 +67,16 @@ class JupyterEnvironment(BaseModel, allow_mutation=False, extra=Extra.forbid):
 
     add_to_path = True
     description: NonEmptyStr
-    path: NonEmptyStr
-    prologue = ""
+    path: Optional[str] = ""
+    modules: Optional[str] = ""
+    prologue: Optional[str] = ""
+
+    # validators
+    @validator("modules")
+    def check_path_or_mods(cls, v: Optional[str], values: dict) -> Optional[str]:
+        if not v and not values.get("path"):
+            raise ValueError(f"Jupyter environment path or modules is required")
+        return v
 
 
 class PartitionConfig(BaseModel, allow_mutation=False, extra=Extra.forbid):
@@ -136,7 +144,9 @@ class UserOptions(BaseModel):
     ngpus: NonNegativeInt = 0
     options = ""
     output = "/dev/null"
+    environment_id = ""
     environment_path = ""
+    environment_modules = ""
     default_url = ""
     root_dir = ""
     # Extra fields

--- a/jupyterhub_moss/spawner.py
+++ b/jupyterhub_moss/spawner.py
@@ -371,8 +371,12 @@ class MOSlurmSpawner(SlurmSpawner):
         self.notebook_dir = self.user_options["root_dir"]
 
         environment_id = self.user_options["environment_id"]
-        self.log.info(f"Used environment: {environment_id}")
-        self.__update_spawn_commands(self.user_options["environment_path"])
+        environment_path = self.user_options["environment_path"]
+        environment_modules = self.user_options["environment_modules"]
+        self.log.info(
+            f"Used environment: ID: {environment_id}, path: {environment_path}, modules: {environment_modules}"
+        )
+        self.__update_spawn_commands(environment_path)
 
         return await super().start()
 

--- a/jupyterhub_moss/spawner.py
+++ b/jupyterhub_moss/spawner.py
@@ -54,9 +54,10 @@ class MOSlurmSpawner(SlurmSpawner):
                     value_trait=traitlets.Dict(
                         key_trait=traitlets.Unicode(),
                         per_key_traits={
-                            "path": traitlets.Unicode(),
                             "description": traitlets.Unicode(),
                             "add_to_path": traitlets.Bool(),
+                            "path": traitlets.Unicode(),
+                            "modules": traitlets.Unicode(),
                             "prologue": traitlets.Unicode(),
                         },
                     ),
@@ -316,13 +317,17 @@ class MOSlurmSpawner(SlurmSpawner):
                 raise RuntimeError("GPU(s) not available for this partition")
             options.gres = gpu_gres_template.format(options.ngpus)
 
-        partition_environments = tuple(partition_info.jupyter_environments.values())
-        if not options.environment_path:
-            # Set path to use from first environment for the current partition
-            options.environment_path = partition_environments[0].path
+        partition_envs = self.partitions[options.partition]["jupyter_environments"]
+
+        # Custom envs are always added to PATH
+        # Defaults envs only if add_to_path is True
+        prologue_env_path = options.environment_path
+        if options.environment_id in partition_envs:
+            if not partition_envs[options.environment_id]["add_to_path"]:
+                prologue_env_path = ""
 
         options.prologue = create_prologue(
-            self.req_prologue, options.environment_path, partition_environments
+            self.req_prologue, prologue_env_path, options.environment_modules
         )
 
     async def options_from_form(self, formdata: dict[str, list[str]]) -> dict:
@@ -366,9 +371,9 @@ class MOSlurmSpawner(SlurmSpawner):
 
         self.notebook_dir = self.user_options["root_dir"]
 
-        environment_path = self.user_options["environment_path"]
-        self.log.info(f"Used environment: {environment_path}")
-        self.__update_spawn_commands(environment_path)
+        environment_id = self.user_options["environment_id"]
+        self.log.info(f"Used environment: {environment_id}")
+        self.__update_spawn_commands(self.user_options["environment_path"])
 
         return await super().start()
 

--- a/jupyterhub_moss/spawner.py
+++ b/jupyterhub_moss/spawner.py
@@ -317,7 +317,7 @@ class MOSlurmSpawner(SlurmSpawner):
                 raise RuntimeError("GPU(s) not available for this partition")
             options.gres = gpu_gres_template.format(options.ngpus)
 
-        partition_envs = self.partitions[options.partition]["jupyter_environments"]
+        partition_envs = partition_info.jupyter_environments
 
         # Custom envs are always added to PATH
         # Defaults envs only if add_to_path is True

--- a/jupyterhub_moss/spawner.py
+++ b/jupyterhub_moss/spawner.py
@@ -317,13 +317,12 @@ class MOSlurmSpawner(SlurmSpawner):
                 raise RuntimeError("GPU(s) not available for this partition")
             options.gres = gpu_gres_template.format(options.ngpus)
 
-        partition_envs = partition_info.jupyter_environments
-
         # Custom envs are always added to PATH
-        # Defaults envs only if add_to_path is True
         prologue_env_path = options.environment_path
-        if options.environment_id in partition_envs:
-            if not partition_envs[options.environment_id]["add_to_path"]:
+        # Default envs only added to PATH if add_to_path is True
+        partition_default_envs = partition_info.jupyter_environments
+        if options.environment_id in partition_default_envs:
+            if not partition_default_envs[options.environment_id].add_to_path:
                 prologue_env_path = ""
 
         options.prologue = create_prologue(

--- a/jupyterhub_moss/templates/option_form.html
+++ b/jupyterhub_moss/templates/option_form.html
@@ -262,7 +262,7 @@ window.SLURM_DATA = JSON.parse('{{ jsondata }}');
               title="Add this environment to &#13;the list of custom environments"
               disabled
             >
-              &#xff0b;
+              Add custom environment
             </button>
           </div>
           <div>

--- a/jupyterhub_moss/templates/option_form.html
+++ b/jupyterhub_moss/templates/option_form.html
@@ -1,5 +1,5 @@
 {% macro resource_tab_footer(partitions, simple_only) %}
-<h4 style="text-align: center">Available resources</h4>
+<h4 class="subheading">Available resources</h4>
 <table class="table">
   <tr class="active">
     <th style="padding-right: 10rem;">Partition</th>
@@ -37,7 +37,7 @@ window.SLURM_DATA = JSON.parse('{{ jsondata }}');
 </ul>
 <div class="tab-content">
   <div id="home" class="tab-pane fade in active">
-    <p class="subheading">Partition</p>
+    <h4 class="subheading">Partition</h4>
     <div class="radio-toolbar">
       {% for name, partition in partitions.items() %}
       {% if partition.simple %}
@@ -57,7 +57,7 @@ window.SLURM_DATA = JSON.parse('{{ jsondata }}');
       {% endif %}
       {% endfor %}
     </div>
-    <p class="subheading">CPUs</p>
+    <h4 class="subheading">CPUs</h4>
     <div class="radio-toolbar">
       <input
         type="radio"
@@ -93,7 +93,7 @@ window.SLURM_DATA = JSON.parse('{{ jsondata }}');
     </div>
 
     <div id="gpu_simple" hidden>
-    <p class="subheading">GPUs</p>
+    <h4 class="subheading">GPUs</h4>
     <div class="radio-toolbar">
       {% set ns = namespace(max_ngpus=0) %}
       {% for partition in partitions.values() %}
@@ -112,7 +112,7 @@ window.SLURM_DATA = JSON.parse('{{ jsondata }}');
       {% endfor %}
     </div>
     </div>
-    <p class="subheading">Options</p>
+    <h4 class="subheading">Options</h4>
     <div class="form-container">
       <label for="environment_simple" accesskey="e">
         Jupyter environment:

--- a/jupyterhub_moss/templates/option_form.html
+++ b/jupyterhub_moss/templates/option_form.html
@@ -257,7 +257,7 @@ window.SLURM_DATA = JSON.parse('{{ jsondata }}');
             <input
               type="text"
               id="environment_add_modules"
-              placeholder="List of modules (space separated)"
+              placeholder="List of modules (space-separated)"
             />
             <button
               type="button"

--- a/jupyterhub_moss/templates/option_form.html
+++ b/jupyterhub_moss/templates/option_form.html
@@ -226,6 +226,8 @@ window.SLURM_DATA = JSON.parse('{{ jsondata }}');
     />
     <label>Jupyter environment:</label>
     <div id="jupyter_environments" class="form-offset-row">
+      <input type="hidden" id="environment_path" name="environment_path"/>
+      <input type="hidden" id="environment_modules" name="environment_modules"/>
       <div id="jupyter_environments_default"></div>
       <div>Custom:</div>
       <div id="jupyter_environments_custom"></div>
@@ -234,7 +236,7 @@ window.SLURM_DATA = JSON.parse('{{ jsondata }}');
         <input
           type="radio"
           id="environment_add_radio"
-          name="environment_path"
+          name="environment_id"
           value=""
         />
         <div>
@@ -248,6 +250,11 @@ window.SLURM_DATA = JSON.parse('{{ jsondata }}');
               type="text"
               id="environment_add_path"
               placeholder="/path/to/jupyter/env/bin *"
+            />
+            <input
+              type="text"
+              id="environment_add_modules"
+              placeholder="List of modules (space separated)"
             />
             <button
               type="button"

--- a/jupyterhub_moss/utils.py
+++ b/jupyterhub_moss/utils.py
@@ -52,12 +52,9 @@ def create_prologue(
     """Create prologue commands"""
     prologue = default_prologue
 
-    # Singularity images are never added to PATH
-    if environment_path.endswith(".sif"):
-        return prologue
-
     # Prepend path to environement
-    if environment_path:
+    # Singularity images are never added to PATH
+    if environment_path and not environment_path.endswith(".sif"):
         prologue += f'\nexport PATH="{environment_path}:$PATH"'
 
     # Load environment modules

--- a/jupyterhub_moss/utils.py
+++ b/jupyterhub_moss/utils.py
@@ -52,13 +52,13 @@ def create_prologue(
     """Create prologue commands"""
     prologue = default_prologue
 
+    # Load environment modules
+    if environment_modules:
+        prologue += f"\nmodule load {environment_modules}"
+
     # Prepend path to environement
     # Singularity images are never added to PATH
     if environment_path and not environment_path.endswith(".sif"):
         prologue += f'\nexport PATH="{environment_path}:$PATH"'
-
-    # Load environment modules
-    if environment_modules:
-        prologue += f"\nmodule load {environment_modules}"
 
     return prologue

--- a/test/test_spawn_page.py
+++ b/test/test_spawn_page.py
@@ -28,9 +28,14 @@ class MOSSMockSimple(MOSlurmSpawnerMock):
                 "simple": True,
                 "jupyter_environments": {
                     "default": {
+                        "description": "Virtual environment",
                         "path": "/default/jupyter_env_path/bin/",
-                        "description": "default",
                         "add_to_path": True,
+                    },
+                    "modules": {
+                        "description": "Environment modules",
+                        "modules": "JupyterLab/3.6.0",
+                        "add_to_path": False,
                     },
                 },
             },
@@ -66,9 +71,16 @@ async def test_spawn_page(app):
                 "simple": True,
                 "jupyter_environments": {
                     "default": {
+                        "description": "Virtual environment",
                         "path": "/default/jupyter_env_path/bin/",
-                        "description": "default",
+                        "modules": "",
                         "add_to_path": True,
+                    },
+                    "modules": {
+                        "description": "Environment modules",
+                        "path": "",
+                        "modules": "JupyterLab/3.6.0",
+                        "add_to_path": False,
                     },
                 },
             }


### PR DESCRIPTION
Fixes #98 

Hello, this PR adds an extra field to the Jupyter environments defined for each `MOSlurmSpawner.partitions` where users can add a space separated list of modules to be load prior to launch the single user server.

The main change is that the `path` attribute of environments becomes optional. Now either one of `modules` or `path` is required (or both). I added a check on `pydantic` to make sure that at least one is defined.

The demo config shows what can be done with this PR.

Changelog:
* add `modules` attribute to `jupyter_environments`
* make either `path` or `modules` a requirement for each `jupyter_environments`
* use the key of each `jupyter_environments` to refer to the environments through `environment_id`
* logic needing access to the list of environments moved out of `utils.create_prologue()`
* update the README
* update the demo config
* style changes: make environment menu bigger and all subheadings use the same style