### PR TITLE
Fix tests with jupyterhub v4 and update lint-test.yml

### DIFF
--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -1,4 +1,4 @@
-name: Lint
+name: Lint&Test
 
 on:
   push:
@@ -9,16 +9,16 @@ on:
       - main
 
 jobs:
-  lint:
+  lint-test:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout 🏷️
         uses: actions/checkout@v3
 
       - name: Set up Python 🐍
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
-          python-version: 3.8
+          python-version: '3.8'
 
       - name: Install dependencies ⚙️
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,27 +10,27 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - name: Checkout 🏷️
-      uses: actions/checkout@v2
+      - name: Checkout 🏷️
+        uses: actions/checkout@v3
 
-    - name: Set up Python 🐍
-      uses: actions/setup-python@v2
-      with:
-        python-version: '3.10'
+      - name: Set up Python 🐍
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
 
-    - name: Install dependencies ⚙️
-      run: |
-        python -m pip install --upgrade pip
-        pip install build twine
+      - name: Install dependencies ⚙️
+        run: |
+          python -m pip install --upgrade pip
+          pip install build twine
 
-    - name: Build the package 📦
-      run: python -m build
+      - name: Build the package 📦
+        run: python -m build
 
-    - name: Check the package 🧐
-      run: python -m twine check dist/*
-    
-    - name: Release on PyPI 🎉
-      env:
-        TWINE_USERNAME: __token__
-        TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
-      run: python -m twine upload dist/*
+      - name: Check the package 🧐
+        run: python -m twine check dist/*
+
+      - name: Release on PyPI 🎉
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
+        run: python -m twine upload dist/*

--- a/test/utils.py
+++ b/test/utils.py
@@ -5,13 +5,18 @@ from traitlets import Unicode, default
 from jupyterhub_moss import MOSlurmSpawner
 
 
-def post_request(path, app, **kwargs):
+def post_request(path, app, data, cookies=None, **kwargs):
     """Send a POST request on the hub
 
     Similar to jupyterhub.tests.utils.get_page
     """
+    if cookies is not None and "_xsrf" in cookies:
+        data["_xsrf"] = cookies["_xsrf"]
+
     base_url = url_path_join(public_host(app), app.hub.base_url)
-    return async_requests.post(url_path_join(base_url, path), **kwargs)
+    return async_requests.post(
+        url_path_join(base_url, path), data=data, cookies=cookies, **kwargs
+    )
 
 
 class MOSlurmSpawnerMock(MOSlurmSpawner):


### PR DESCRIPTION
This PR:

- Fix tests with jupyterhub v4 which makes CI fails. This should be related to https://github.com/jupyterhub/jupyterhub/pull/4032
- Update the CI config to fix this warning:
> Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: actions/setup-python@v2. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.
