### PR TITLE
Added a `stylesheet` block to jinja's `options_form.html` template

### DIFF
--- a/demo/templates/option_form.html
+++ b/demo/templates/option_form.html
@@ -17,6 +17,16 @@
 </table>
 {% endmacro %}
 
+{% block stylesheet %}
+{{ super() }}
+<style>
+#environment_simple {
+  color: #f37524;
+  font-weight: 900;
+}
+</style>
+{% endblock %}
+
 {% block simple_tab_footer %}
 {{ resource_table(partitions, simple_only=true) }}
 {% endblock simple_tab_footer %}

--- a/jupyterhub_moss/templates/option_form.html
+++ b/jupyterhub_moss/templates/option_form.html
@@ -18,7 +18,10 @@
 </table>
 {% endmacro %}
 
+{% block stylesheet %}
 <link href="/hub/form/option_form.css?v={{hash_option_form_css}}" rel="stylesheet" />
+{% endblock %}
+
 <script>
 window.SLURM_DATA = JSON.parse('{{ jsondata }}');
 </script>


### PR DESCRIPTION
This PR adds a block for the stylesheet in the `options_form.html` template, to allow one to override the style.

The `<link>` to the stylesheet of the options' form is set in the html `<body>` and this PR keeps this as it was.
Defining the style outside `<head>` is supported, is not recommended but looks to be used.

I gave a try have the style in the `<head>` through a custom `spawn.html` template. It involves setting `c.JupyterHub.template_paths` and `c.JupyterHub.template_vars`... and then it is more complicated to custom the templates when using `jupyterhub_moss`.

related to #99