### PR TITLE
Fixed GPU resource parsing and pydantic support

### DIFF
--- a/jupyterhub_moss/models.py
+++ b/jupyterhub_moss/models.py
@@ -119,7 +119,7 @@ class PartitionsTrait(RootModel):
 
     root: Dict[str, _PartitionTraits]
 
-    model_config = ConfigDict(frozen=True, extra="forbid")
+    model_config = ConfigDict(frozen=True)
 
     def model_dump(self, *args, **kwargs):
         return {k: v.model_dump(*args, **kwargs) for k, v in self.root.items()}

--- a/jupyterhub_moss/utils.py
+++ b/jupyterhub_moss/utils.py
@@ -52,7 +52,7 @@ def parse_gpu_resource(generic_resources: str) -> tuple[str, str]:
 
     Information about the first GPU found is returned if any.
 
-    :returns: (GPU resource template, number of GPUs) or None if the resource is not a GPU.
+    :returns: (GPU resource template, number of GPUs)
     :raises ValueError: If parsing failed.
     """
     for resource in generic_resources.split(","):

--- a/jupyterhub_moss/utils.py
+++ b/jupyterhub_moss/utils.py
@@ -44,6 +44,26 @@ def parse_timelimit(timelimit: str) -> datetime.timedelta:
     )
 
 
+_GPU_GRES_REGEXP = re.compile(r"^gpu:(?P<type_>[^:]+):(?P<count>[0-9]+)(?:\(.*\))?$")
+
+
+def parse_gpu_resource(generic_resources: str) -> tuple[str, str]:
+    """Parse SLURM generic resources (aka., gres) to retrieve GPU information.
+
+    Information about the first GPU found is returned if any.
+
+    :returns: (GPU resource template, number of GPUs) or None if the resource is not a GPU.
+    :raises ValueError: If parsing failed.
+    """
+    for resource in generic_resources.split(","):
+        match = _GPU_GRES_REGEXP.match(resource.strip())
+        if match is None:
+            continue
+        gpu_gres_template = f"gpu:{match['type_']}:{{}}"
+        return gpu_gres_template, match["count"]
+    raise ValueError(f"No GPU resource in '{generic_resources}'.")
+
+
 def create_prologue(
     default_prologue: str,
     environment_path: str,

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -1,0 +1,30 @@
+import pytest
+
+from jupyterhub_moss.utils import parse_gpu_resource
+
+
+@pytest.mark.parametrize(
+    "gres,expected_type,expected_count",
+    [
+        # Single GPU
+        ("gpu:model:2", "model", 2),
+        ("gpu:brand_model-pcie.10:2(S:0-1)", "brand_model-pcie.10", 2),
+        # Multiple GPUs
+        ("gpu:modelA:1,gpu:modelB:3", "modelA", 1),
+        ("gpu:modelA:6(S:0-1),gpu:1g.10gb:28(S:0-1)", "modelA", 6),
+        # Mixed GPU/other resources
+        ("other:nameA:2,gpu:modelA:3,other:nameB:2", "modelA", 3),
+    ],
+)
+def test_parse_gpu_gres(gres, expected_type, expected_count):
+    """Test parse_gpu_gres function of valid GPU resources"""
+    generated_template, generated_count = parse_gpu_resource(gres)
+    assert generated_template == f"gpu:{expected_type}:{{}}"
+    assert int(generated_count) == expected_count
+
+
+@pytest.mark.parametrize("gres", ["(null)", "other:name:2"])
+def test_parse_gpu_gres_failed(gres):
+    """Test cases where parse_gpu_gres raises an exception"""
+    with pytest.raises(ValueError):
+        parse_gpu_resource(gres)


### PR DESCRIPTION
This PR fixes 2 issues:
- GPU resource parsing failures when there is more than one GPU or other resources (Related to issue #104). Some unit tests were added for the parsing. As it stands, there is no real support for multiple GPUs, this PR only avoids to raise an exception and pick the first GPU in the list (this can be overridden in the config).

- An error occuring with current latest version of `pydantic` (v2.2.1):
```
PydanticUserError: RootModel does not support setting `model_config['extra']`
```
