### PR TITLE
Improved handling of `environment_id` request param

### DIFF
--- a/jupyterhub_moss/form/option_form.js
+++ b/jupyterhub_moss/form/option_form.js
@@ -7,7 +7,7 @@ function removeAllChildren(node) {
   }
 }
 
-function createEnvironmentDiv(key, description, path, modules, checked = false) {
+function createEnvironmentDiv(key, description, path, modules, iscustom = false) {
   const div = document.createElement('div');
   div.classList.add('environment-div');
 
@@ -18,12 +18,12 @@ function createEnvironmentDiv(key, description, path, modules, checked = false) 
   const path_input = document.createElement('input');
   path_input.setAttribute('type', 'hidden');
   path_input.setAttribute('class', 'environment_path');
-  path_input.setAttribute('value', path);
+  path_input.setAttribute('value', iscustom ? path : '');
   div.appendChild(path_input);
   const mods_input = document.createElement('input');
   mods_input.setAttribute('type', 'hidden');
   mods_input.setAttribute('class', 'environment_modules');
-  mods_input.setAttribute('value', modules);
+  mods_input.setAttribute('value', iscustom ? modules : '');
   div.appendChild(mods_input);
 
   const input = document.createElement('input');
@@ -34,9 +34,6 @@ function createEnvironmentDiv(key, description, path, modules, checked = false) 
   input.setAttribute('value', key);
 
   input.addEventListener('change', updateAddCustomEnvironment);
-  if (checked) {
-    input.setAttribute('checked', '');
-  }
   div.appendChild(input);
 
   const label = document.createElement('label');
@@ -96,7 +93,7 @@ function addCustomEnvironment(key, description, path, modules, persist = true) {
     'environment_simple_custom'
   );
 
-  const div = createEnvironmentDiv(key, description, path, modules);
+  const div = createEnvironmentDiv(key, description, path, modules, true);
 
   button = document.createElement('button');
   button.setAttribute('type', 'button');
@@ -236,7 +233,7 @@ function updateDefaultEnvironments() {
     const info = partitionInfo.jupyter_environments[key];
 
     defaultEnvironmentsDiv.appendChild(
-      createEnvironmentDiv(key, info.description, info.path, info.modules)
+      createEnvironmentDiv(key, info.description, info.path, info.modules, false)
     );
 
     const option = document.createElement('option');


### PR DESCRIPTION
This PR reworks the handling/consistency of `environment_id`, `environment_path` and `environment_modules` request params. This changes nothing for usage from the spawn page but simplifies spawning with a URL.

Beforehand, to use an environment defined in the spawner config, those 3 fields needed to be provided in the request.
While it's OK for POST requests sent by the spawn page, it is cumbersome to write a URL to spawn with a GET request. It is also error prone to use path and modules from the request rather than those from the config.

With this PR when `environment_id` corresponds to an environment defined in the server config, `environment_path` and `environment_modules` are taken from the config rather than from the request.

Also, if none of those 3 fields is defined, it uses the first jupyter environment of the partition as default (this was lost in PR #99).

Finally, a test is added for providing only `environment_id` and test utils are updated to ease testing both GET and POST request at once.