### PR TITLE
Added support of Jupyterhub v5

### DIFF
--- a/demo/jupyterhub_conf.py
+++ b/demo/jupyterhub_conf.py
@@ -95,3 +95,6 @@ c.BatchSpawnerBase.exec_prefix = ""
 c.JupyterHub.ip = "127.0.0.1"
 c.JupyterHub.hub_ip = "127.0.0.1"
 c.JupyterHub.port = 8000
+
+# Demo: Allow any user
+c.Authenticator.allow_all = True

--- a/jupyterhub_moss/models.py
+++ b/jupyterhub_moss/models.py
@@ -8,16 +8,16 @@ from pydantic import (
     field_validator,
     BaseModel,
     ConfigDict,
-    FieldValidationInfo,
     NonNegativeInt,
     PositiveInt,
     RootModel,
+    ValidationInfo,
 )
 
 # Validators
 
 
-def check_match_gpu(v: Optional[int], info: FieldValidationInfo) -> Optional[int]:
+def check_match_gpu(v: Optional[int], info: ValidationInfo) -> Optional[int]:
     if v is not None and v > 0 and info.data.get("gpu") == "":
         return 0  # GPU explicitly disabled
     return v
@@ -69,7 +69,7 @@ class JupyterEnvironment(BaseModel, frozen=True, extra="forbid"):
 
     # validators
     @field_validator("modules")
-    def check_path_or_mods(cls, v: str, info: FieldValidationInfo) -> str:
+    def check_path_or_mods(cls, v: str, info: ValidationInfo) -> str:
         if not v and not info.data.get("path"):
             raise ValueError("Jupyter environment path or modules is required")
         return v

--- a/jupyterhub_moss/templates/option_form.html
+++ b/jupyterhub_moss/templates/option_form.html
@@ -31,15 +31,19 @@ window.SLURM_DATA = JSON.parse('{{ jsondata }}');
   charset="utf-8"
 ></script>
 <ul class="nav nav-tabs nav-justified">
-  <li class="active">
-    <a data-toggle="tab" href="#home" id="simple_tab_link">
+  <li class="nav-item">
+    <a  class="nav-link active" data-bs-toggle="tab" href="#home" id="simple_tab_link" >
       Simple
     </a>
   </li>
-  <li><a data-toggle="tab" href="#menu1" id="advanced_tab_link">Advanced</a></li>
+  <li class="nav-item">
+    <a class="nav-link" data-bs-toggle="tab" href="#menu1" id="advanced_tab_link">
+      Advanced
+    </a>
+  </li>
 </ul>
 <div class="tab-content">
-  <div id="home" class="tab-pane fade in active">
+  <div id="home" class="tab-pane fade show active">
     <h4 class="subheading">Partition</h4>
     <div class="radio-toolbar">
       {% for name, partition in partitions.items() %}

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,7 +26,7 @@ install_requires =
     batchspawner>=1.0
     jinja2
     jupyterhub>=5.0.0
-    pydantic>=2.0,<3
+    pydantic>=2.4.0,<3
     traitlets
 
 [options.extras_require]

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,7 +25,7 @@ python_requires = >=3.8
 install_requires =
     batchspawner>=1.0
     jinja2
-    jupyterhub
+    jupyterhub>=5.0.0
     pydantic>=2.0,<3
     traitlets
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -39,7 +39,7 @@ dev =
     jupyter_server
     mypy
     pytest
-    pytest-asyncio
+    pytest-asyncio>=0.17,<0.23
 
 # E501 (line too long) ignored
 # E203 and W503 incompatible with black formatting (https://black.readthedocs.io/en/stable/compatible_configs.html#flake8)


### PR DESCRIPTION
This PR migrates the spawn options form to bootstrap 5 to support jupyterhub v5.
This makes is no longer compatible with older version of jupyterhub.

This still need some testing but it works fine with the [demo config](https://github.com/silx-kit/jupyterhub_moss/blob/main/demo/jupyterhub_conf.py)

attn @rclUPC

closes #111