### PR TITLE
Updated continuous integration worflows

### DIFF
--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -13,10 +13,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout 🏷️
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Python 🐍
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.8'
 
@@ -41,10 +41,10 @@ jobs:
       - name: check-manifest 📰
         run: check-manifest
 
-      - name: Install Node v16
-        uses: actions/setup-node@v3
+      - name: Install Node v20
+        uses: actions/setup-node@v4
         with:
-          node-version: '16'
+          node-version: 20
 
       - name: Install configurable-http-proxy
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,22 +1,22 @@
 name: Release
 
 on:
-  push:
-    tags:
-      - v*
+  workflow_dispatch:
+  release:
+    types:
+      - published
 
 jobs:
   release:
     runs-on: ubuntu-latest
-
     steps:
       - name: Checkout 🏷️
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Python 🐍
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
-          python-version: '3.10'
+          python-version: '3.12'
 
       - name: Install dependencies ⚙️
         run: |
@@ -29,8 +29,23 @@ jobs:
       - name: Check the package 🧐
         run: python -m twine check dist/*
 
-      - name: Release on PyPI 🎉
-        env:
-          TWINE_USERNAME: __token__
-          TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
-        run: python -m twine upload dist/*
+      - uses: actions/upload-artifact@v4
+        with:
+          path: dist/
+
+  pypi-publish:
+    needs: [release]
+    name: Upload release to PyPI
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+    permissions:
+      id-token: write
+    if: github.event_name == 'release' && github.event.action == 'published'
+    # or, alternatively, upload to PyPI on every tag starting with 'v' (remove on: release above to use this)
+    # if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          path: dist
+      - uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
~~Merge PR #112 first! (included here since it fixes the CI)~~

This PR:
- updates the actions used by CI workflow
- updates the release workflow to run on github release publication and relying on github environment rather than pypi secret token