### PR TITLE
Fixed support of jupyterhub with custom `base_url`

### DIFF
--- a/jupyterhub_moss/spawner.py
+++ b/jupyterhub_moss/spawner.py
@@ -271,9 +271,11 @@ class MOSlurmSpawner(SlurmSpawner):
             }
         )
 
+        hub_base_url = spawner.handler.hub.base_url.rstrip("/")
+
         return spawner.__option_form_template.render(
-            hash_option_form_css=RESOURCES_HASH["option_form.css"],
-            hash_option_form_js=RESOURCES_HASH["option_form.js"],
+            option_form_css=f"{hub_base_url}/form/option_form.css?v={RESOURCES_HASH['option_form.css']}",
+            option_form_js=f"{hub_base_url}/form/option_form.js?v={RESOURCES_HASH['option_form.js']}",
             partitions=partitions_dict,
             default_partition=default_partition,
             batchspawner_version=BATCHSPAWNER_VERSION,

--- a/jupyterhub_moss/templates/option_form.html
+++ b/jupyterhub_moss/templates/option_form.html
@@ -19,17 +19,13 @@
 {% endmacro %}
 
 {% block stylesheet %}
-<link href="/hub/form/option_form.css?v={{hash_option_form_css}}" rel="stylesheet" />
+<link href="{{ option_form_css }}" rel="stylesheet" />
 {% endblock %}
 
 <script>
 window.SLURM_DATA = JSON.parse('{{ jsondata }}');
 </script>
-<script
-  src="/hub/form/option_form.js?v={{hash_option_form_js}}"
-  type="text/javascript"
-  charset="utf-8"
-></script>
+<script src="{{ option_form_js }}" type="text/javascript" charset="utf-8"></script>
 <ul class="nav nav-tabs nav-justified">
   <li class="nav-item">
     <a  class="nav-link active" data-bs-toggle="tab" href="#home" id="simple_tab_link" >


### PR DESCRIPTION
use hub's `base_url` instead of hardcoded `/hub/` prefix for js and css resources.

closes #121
